### PR TITLE
Add new expression parentheses rule

### DIFF
--- a/src/PhpCsFixer/Operator.php
+++ b/src/PhpCsFixer/Operator.php
@@ -9,6 +9,7 @@ use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
 use PhpCsFixer\Fixer\Operator\ConcatSpaceFixer;
 use PhpCsFixer\Fixer\Operator\IncrementStyleFixer;
 use PhpCsFixer\Fixer\Operator\LogicalOperatorsFixer;
+use PhpCsFixer\Fixer\Operator\NewExpressionParenthesesFixer;
 use PhpCsFixer\Fixer\Operator\NewWithBracesFixer;
 use PhpCsFixer\Fixer\Operator\NoSpaceAroundDoubleColonFixer;
 use PhpCsFixer\Fixer\Operator\NotOperatorWithSpaceFixer;
@@ -30,6 +31,7 @@ return register_fixers([
     ConcatSpaceFixer::class => [ 'spacing' => 'one' ],
     IncrementStyleFixer::class => [ 'style' => 'post' ],
     LogicalOperatorsFixer::class => true,
+    NewExpressionParenthesesFixer::class => [ 'use_parentheses' => false ],
     NewWithBracesFixer::class => true,
     NoSpaceAroundDoubleColonFixer::class => true,
     NotOperatorWithSpaceFixer::class => false,

--- a/tests/Fixtures/NewExpressionParenthesesFixer/After/Example.php
+++ b/tests/Fixtures/NewExpressionParenthesesFixer/After/Example.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\NewExpressionParenthesesFixer;
+
+final class Example
+{
+    public function build(): object
+    {
+        return new MyClass()->abc();
+    }
+}

--- a/tests/Fixtures/NewExpressionParenthesesFixer/Before/Example.php
+++ b/tests/Fixtures/NewExpressionParenthesesFixer/Before/Example.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\NewExpressionParenthesesFixer;
+
+final class Example
+{
+    public function build(): object
+    {
+        return (new MyClass())->abc();
+    }
+}

--- a/tests/NewExpressionParenthesesFixerTest.php
+++ b/tests/NewExpressionParenthesesFixerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests;
+
+use DigitalCreative\ECS\Tests\Support\EcsTestCase;
+
+final class NewExpressionParenthesesFixerTest extends EcsTestCase
+{
+    public function test_parentheses_are_removed_from_chained_new_expressions(): void
+    {
+        $fixtureDirectory = __DIR__ . '/Fixtures/NewExpressionParenthesesFixer';
+
+        $this->assertFixtureIsFixedTo(
+            $fixtureDirectory . '/Before/Example.php',
+            $fixtureDirectory . '/After/Example.php',
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- enable PHP-CS-Fixer's `new_expression_parentheses` rule without wrapper parentheses
- normalize `(new MyClass())->abc()` to `new MyClass()->abc()`
- add fixture-based regression coverage

## Verification
- `php vendor/bin/phpunit --do-not-cache-result tests/NewExpressionParenthesesFixerTest.php` on PHP 8.5.8
- ECS CLI smoke test on PHP 8.5.8 confirmed the fixer and output

## Note
Direct dereferencing of `new` expressions is supported from PHP 8.4; the configured upstream fixer guards itself with `PHP_VERSION_ID >= 80400`.