### PR TITLE
Enforce spacing around trait imports

### DIFF
--- a/src/Custom.php
+++ b/src/Custom.php
@@ -12,6 +12,7 @@ use DigitalCreative\ECS\Fixers\PaddedArrayFixer;
 use DigitalCreative\ECS\Fixers\PaddedBlockFixer;
 use DigitalCreative\ECS\Fixers\PaddedMultilineStatementFixer;
 use DigitalCreative\ECS\Fixers\StatementGroupingFixer;
+use DigitalCreative\ECS\Fixers\TraitUseSpacingFixer;
 use DigitalCreative\ECS\Sniffs\RequireParameterTypeSniff;
 
 return register_fixers([
@@ -19,6 +20,7 @@ return register_fixers([
     PaddedBlockFixer::class => true,
     PaddedMultilineStatementFixer::class => true,
     StatementGroupingFixer::class => true,
+    TraitUseSpacingFixer::class => true,
     ClassOpeningBracketFixer::class => true,
     ConstructorBracesFixer::class => true,
     FunctionParameterLayoutFixer::class => true,

--- a/src/Fixers/TraitUseSpacingFixer.php
+++ b/src/Fixers/TraitUseSpacingFixer.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Fixers;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Tokenizer\TokensAnalyzer;
+use SplFileInfo;
+
+final class TraitUseSpacingFixer extends AbstractFixer implements WhitespacesAwareFixerInterface
+{
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Trait imports must be contiguous and separated from the following class member by one blank line.',
+            [],
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(CT::T_USE_TRAIT);
+    }
+
+    public function getPriority(): int
+    {
+        return -1;
+    }
+
+    protected function applyFix(SplFileInfo $file, Tokens $tokens): void
+    {
+        $elementsByClass = [];
+
+        foreach ((new TokensAnalyzer($tokens))->getClassyElements() as $index => $element) {
+            $elementsByClass[ $element[ 'classIndex' ] ][ $index ] = $element[ 'type' ];
+        }
+
+        foreach ($elementsByClass as $elements) {
+
+            ksort($elements);
+
+            $elementIndexes = array_keys($elements);
+            $elementTypes = array_values($elements);
+
+            for ($position = count($elementIndexes) - 1; $position >= 0; $position--) {
+
+                if ($elementTypes[ $position ] !== 'trait_import') {
+                    continue;
+                }
+
+                $nextElementType = $elementTypes[ $position + 1 ] ?? null;
+                $requiredLineBreaks = $nextElementType === null || $nextElementType === 'trait_import' ? 1 : 2;
+                $traitEndIndex = $this->findTraitEndIndex($tokens, $elementIndexes[ $position ]);
+
+                $this->normalizeLineBreaksAfter($tokens, $traitEndIndex, $requiredLineBreaks);
+
+            }
+
+        }
+    }
+
+    private function findTraitEndIndex(Tokens $tokens, int $traitUseIndex): int
+    {
+        $terminatorIndex = $tokens->getNextTokenOfKind($traitUseIndex, [ ';', '{' ]);
+
+        if ($tokens[ $terminatorIndex ]->equals('{')) {
+            return $tokens->findBlockEnd(Tokens::BLOCK_TYPE_BRACE, $terminatorIndex);
+        }
+
+        return $terminatorIndex;
+    }
+
+    private function normalizeLineBreaksAfter(Tokens $tokens, int $traitEndIndex, int $requiredLineBreaks): void
+    {
+        $spacingBoundaryIndex = $this->findSpacingBoundaryIndex($tokens, $traitEndIndex);
+        $whitespaceIndex = $spacingBoundaryIndex + 1;
+        $lineEnding = $this->whitespacesConfig->getLineEnding();
+
+        if (!$tokens[ $whitespaceIndex ]->isWhitespace()) {
+
+            $tokens->insertAt(
+                $whitespaceIndex,
+                new Token([ T_WHITESPACE, str_repeat($lineEnding, $requiredLineBreaks) ]),
+            );
+
+            return;
+
+        }
+
+        $content = $tokens[ $whitespaceIndex ]->getContent();
+        $lastLineBreakPosition = strrpos($content, "\n");
+        $indentation = $lastLineBreakPosition === false ? $content : substr($content, $lastLineBreakPosition + 1);
+
+        $tokens[ $whitespaceIndex ] = new Token([
+            T_WHITESPACE,
+            sprintf('%s%s', str_repeat($lineEnding, $requiredLineBreaks), $indentation),
+        ]);
+    }
+
+    private function findSpacingBoundaryIndex(Tokens $tokens, int $traitEndIndex): int
+    {
+        $nextIndex = $traitEndIndex + 1;
+
+        if ($tokens[ $nextIndex ]->isComment()) {
+            return $nextIndex;
+        }
+
+        if (!$tokens[ $nextIndex ]->isWhitespace() || str_contains($tokens[ $nextIndex ]->getContent(), "\n")) {
+            return $traitEndIndex;
+        }
+
+        $commentIndex = $tokens->getNextNonWhitespace($traitEndIndex);
+
+        if ($commentIndex !== null && $tokens[ $commentIndex ]->isComment()) {
+            return $commentIndex;
+        }
+
+        return $traitEndIndex;
+    }
+}

--- a/tests/Fixtures/TraitUseSpacingFixer/After/MultipleTraitsController.php
+++ b/tests/Fixtures/TraitUseSpacingFixer/After/MultipleTraitsController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\TraitUseSpacingFixer;
+
+final class MultipleTraitsController
+{
+    use AnotherTrait;
+    use ChecksExistingAppointments;
+
+    public function __invoke(BookAppointmentRequest $request): ApiResponse
+    {
+        return $this->response();
+    }
+}

--- a/tests/Fixtures/TraitUseSpacingFixer/After/SingleTraitController.php
+++ b/tests/Fixtures/TraitUseSpacingFixer/After/SingleTraitController.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\TraitUseSpacingFixer;
+
+final class SingleTraitController
+{
+    use ChecksExistingAppointments;
+
+    public function __invoke(BookAppointmentRequest $request): ApiResponse
+    {
+        return $this->response();
+    }
+}

--- a/tests/Fixtures/TraitUseSpacingFixer/After/TraitBeforeProperty.php
+++ b/tests/Fixtures/TraitUseSpacingFixer/After/TraitBeforeProperty.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\TraitUseSpacingFixer;
+
+final class TraitBeforeProperty
+{
+    use ChecksExistingAppointments;
+
+    public ApiResponse $response;
+}

--- a/tests/Fixtures/TraitUseSpacingFixer/Before/MultipleTraitsController.php
+++ b/tests/Fixtures/TraitUseSpacingFixer/Before/MultipleTraitsController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\TraitUseSpacingFixer;
+
+final class MultipleTraitsController
+{
+    use ChecksExistingAppointments;
+
+    use AnotherTrait;
+    public function __invoke(BookAppointmentRequest $request): ApiResponse
+    {
+        return $this->response();
+    }
+}

--- a/tests/Fixtures/TraitUseSpacingFixer/Before/SingleTraitController.php
+++ b/tests/Fixtures/TraitUseSpacingFixer/Before/SingleTraitController.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\TraitUseSpacingFixer;
+
+final class SingleTraitController
+{
+    use ChecksExistingAppointments;
+    public function __invoke(BookAppointmentRequest $request): ApiResponse
+    {
+        return $this->response();
+    }
+}

--- a/tests/Fixtures/TraitUseSpacingFixer/Before/TraitBeforeProperty.php
+++ b/tests/Fixtures/TraitUseSpacingFixer/Before/TraitBeforeProperty.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\TraitUseSpacingFixer;
+
+final class TraitBeforeProperty
+{
+    use ChecksExistingAppointments;
+    public ApiResponse $response;
+}

--- a/tests/TraitUseSpacingFixerTest.php
+++ b/tests/TraitUseSpacingFixerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests;
+
+use DigitalCreative\ECS\Tests\Support\EcsTestCase;
+
+final class TraitUseSpacingFixerTest extends EcsTestCase
+{
+    public function test_single_trait_is_separated_from_following_method(): void
+    {
+        $fixtureDirectory = __DIR__ . '/Fixtures/TraitUseSpacingFixer';
+
+        $this->assertFixtureIsFixedTo(
+            $fixtureDirectory . '/Before/SingleTraitController.php',
+            $fixtureDirectory . '/After/SingleTraitController.php',
+        );
+    }
+
+    public function test_multiple_traits_are_grouped_before_following_method(): void
+    {
+        $fixtureDirectory = __DIR__ . '/Fixtures/TraitUseSpacingFixer';
+
+        $this->assertFixtureIsFixedTo(
+            $fixtureDirectory . '/Before/MultipleTraitsController.php',
+            $fixtureDirectory . '/After/MultipleTraitsController.php',
+        );
+    }
+
+    public function test_trait_is_separated_from_following_property(): void
+    {
+        $fixtureDirectory = __DIR__ . '/Fixtures/TraitUseSpacingFixer';
+
+        $this->assertFixtureIsFixedTo(
+            $fixtureDirectory . '/Before/TraitBeforeProperty.php',
+            $fixtureDirectory . '/After/TraitBeforeProperty.php',
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a custom fixer that keeps adjacent trait imports contiguous
- require exactly one blank line between the final trait import and the following class member
- preserve a single line break when traits are followed directly by the class closing brace
- cover single traits, multiple traits, methods, and properties with native PHP fixtures

## Verification
- `php vendor/bin/phpunit --do-not-cache-result tests/TraitUseSpacingFixerTest.php` on PHP 8.5.8: 3 tests, 6 assertions passed
- ECS CLI smoke test normalized the provided multi-trait controller example and reported `TraitUseSpacingFixer`
- ECS formatting check passed for the changed source and test files after applying the project formatter
- full suite ran 27 tests; 10 unrelated existing fixture assertions still fail only on CRLF/LF line-ending differences