### PR TITLE
Expand inline PHPDoc blocks to multiple lines

### DIFF
--- a/src/PhpCsFixer/Phpdoc.php
+++ b/src/PhpCsFixer/Phpdoc.php
@@ -50,7 +50,7 @@ return register_fixers([
     PhpdocAnnotationWithoutDotFixer::class => false,
     PhpdocIndentFixer::class => true,
     PhpdocInlineTagNormalizerFixer::class => true,
-    PhpdocLineSpanFixer::class => true,
+    PhpdocLineSpanFixer::class => [ 'other' => 'multi' ],
     PhpdocNoAccessFixer::class => true,
     PhpdocNoAliasTagFixer::class => true,
     PhpdocNoEmptyReturnFixer::class => true,

--- a/tests/Fixtures/PhpdocLineSpanFixer/After/ExperimentLookup.php
+++ b/tests/Fixtures/PhpdocLineSpanFixer/After/ExperimentLookup.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\PhpdocLineSpanFixer;
+
+/**
+ * @var Experiment|null $existing
+ */
+$existing = $existingByKey->get($definition->key);

--- a/tests/Fixtures/PhpdocLineSpanFixer/Before/ExperimentLookup.php
+++ b/tests/Fixtures/PhpdocLineSpanFixer/Before/ExperimentLookup.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\PhpdocLineSpanFixer;
+
+/** @var Experiment|null $existing */
+$existing = $existingByKey->get($definition->key);

--- a/tests/PhpdocLineSpanFixerTest.php
+++ b/tests/PhpdocLineSpanFixerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests;
+
+use DigitalCreative\ECS\Tests\Support\EcsTestCase;
+
+final class PhpdocLineSpanFixerTest extends EcsTestCase
+{
+    public function test_inline_variable_docblock_is_expanded_to_multiple_lines(): void
+    {
+        $fixtureDirectory = __DIR__ . '/Fixtures/PhpdocLineSpanFixer';
+
+        $this->assertFixtureIsFixedTo(
+            $fixtureDirectory . '/Before/ExperimentLookup.php',
+            $fixtureDirectory . '/After/ExperimentLookup.php',
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- configure `PhpdocLineSpanFixer` with `other => multi`
- expand inline variable PHPDoc such as `/** @var Experiment|null $existing */` into the canonical multiline form
- add native before/after fixture regression coverage

## Verification
- `php vendor/bin/phpunit --do-not-cache-result tests/PhpdocLineSpanFixerTest.php` on PHP 8.5.8: 1 test, 2 assertions passed
- ECS CLI smoke test transformed the provided assignment example and reported `PhpdocLineSpanFixer`
- changed source and test files were processed with the project formatter
- full suite ran 25 tests; 10 unrelated existing fixture assertions still fail only on CRLF/LF line-ending differences