### PR TITLE
Add descriptive variable name fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Standard code style configuration",
     "require": {
         "php": ">=8.4",
+        "nikic/php-parser": "^5.6",
         "symplify/easy-coding-standard": "^13.0.4"
     },
     "require-dev": {

--- a/src/Custom.php
+++ b/src/Custom.php
@@ -6,6 +6,7 @@ namespace DigitalCreative\ECS;
 
 use DigitalCreative\ECS\Fixers\ClassOpeningBracketFixer;
 use DigitalCreative\ECS\Fixers\ConstructorBracesFixer;
+use DigitalCreative\ECS\Fixers\DescriptiveVariableNameFixer;
 use DigitalCreative\ECS\Fixers\FunctionParameterLayoutFixer;
 use DigitalCreative\ECS\Fixers\LaravelEmptyToBlankFixer;
 use DigitalCreative\ECS\Fixers\PaddedArrayFixer;
@@ -21,6 +22,7 @@ return register_fixers([
     StatementGroupingFixer::class => true,
     ClassOpeningBracketFixer::class => true,
     ConstructorBracesFixer::class => true,
+    DescriptiveVariableNameFixer::class => true,
     FunctionParameterLayoutFixer::class => true,
     RequireParameterTypeSniff::class => true,
     LaravelEmptyToBlankFixer::class => true,

--- a/src/Fixers/DescriptiveVariableNameFixer.php
+++ b/src/Fixers/DescriptiveVariableNameFixer.php
@@ -1,0 +1,624 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Fixers;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpParser\Error;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\IntersectionType;
+use PhpParser\Node\Name;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\Param;
+use PhpParser\Node\StaticVar;
+use PhpParser\Node\Stmt\Catch_;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Global_;
+use PhpParser\Node\UnionType;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+use SplFileInfo;
+
+final class DescriptiveVariableNameFixer extends AbstractFixer
+{
+    /**
+     * Types that do not carry enough meaning for a descriptive variable name.
+     *
+     * @var list<string>
+     */
+    private const array IGNORED_TYPE_NAMES = [
+        'false',
+        'mixed',
+        'never',
+        'null',
+        'parent',
+        'self',
+        'static',
+        'true',
+        'void',
+    ];
+
+    /**
+     * Generic class suffixes that describe the declaration rather than the value.
+     *
+     * @var list<string>
+     */
+    private const array TYPE_SUFFIXES = [
+        'contract',
+        'interface',
+    ];
+
+    private readonly Parser $parser;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->parser = (new ParserFactory())->createForNewestSupportedVersion();
+    }
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Typed function parameters must use descriptive names inferred from their types.',
+            [
+                new CodeSample(<<<'PHP'
+                <?php
+
+                array_map(static fn (Permission $p): string => $p->ability(), $permissions);
+                PHP),
+            ],
+            null,
+            'Renaming a function parameter can affect calls that use named arguments or reflection.',
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_VARIABLE)
+            && $tokens->isAnyTokenKindsFound([ T_FN, T_FUNCTION ]);
+    }
+
+    public function isRisky(): bool
+    {
+        return true;
+    }
+
+    protected function applyFix(SplFileInfo $file, Tokens $tokens): void
+    {
+        $code = $tokens->generateCode();
+
+        try {
+
+            $statements = $this->parser->parse($code);
+
+            if ($statements === null) {
+                return;
+            }
+
+            $statements = (new NodeTraverser(new NameResolver(options: [ 'replaceNodes' => false ])))
+                ->traverse($statements);
+
+        } catch (Error) {
+
+            return;
+
+        }
+
+        /**
+         * @var array<int, array{end: int, replacement: string}> $edits
+         */
+        $edits = [];
+
+        /**
+         * @var array<int, true> $conflicts
+         */
+        $conflicts = [];
+
+        $this->collectEdits($statements, $edits, $conflicts);
+
+        krsort($edits);
+
+        foreach ($edits as $start => $edit) {
+
+            $code = substr_replace(
+                $code,
+                $edit[ 'replacement' ],
+                $start,
+                $edit[ 'end' ] - $start + 1,
+            );
+
+        }
+
+        $tokens->setCode($code);
+    }
+
+    /**
+     * @param array<Node>|Node|null $node
+     * @param array<int, array{end: int, replacement: string}> $edits
+     * @param array<int, true> $conflicts
+     */
+    private function collectEdits(Node|array|null $node, array &$edits, array &$conflicts): void
+    {
+        if ($node instanceof FunctionLike) {
+            $this->collectFunctionEdits($node, $edits, $conflicts);
+        }
+
+        if (is_array($node)) {
+
+            foreach ($node as $child) {
+                $this->collectEdits($child, $edits, $conflicts);
+            }
+
+            return;
+
+        }
+
+        if ($node === null) {
+            return;
+        }
+
+        foreach ($node->getSubNodeNames() as $subNodeName) {
+
+            $subNode = $node->{$subNodeName};
+
+            if ($subNode instanceof Node || is_array($subNode)) {
+                $this->collectEdits($subNode, $edits, $conflicts);
+            }
+
+        }
+    }
+
+    /**
+     * @param array<int, array{end: int, replacement: string}> $edits
+     * @param array<int, true> $conflicts
+     */
+    private function collectFunctionEdits(FunctionLike $function, array &$edits, array &$conflicts): void
+    {
+        /**
+         * @var list<array{param: Param, current: string, inferred: array{name: string, abbreviations: list<string>}}> $candidates
+         */
+        $candidates = [];
+        $inferredNameCounts = [];
+
+        foreach ($function->getParams() as $param) {
+
+            if (!$param->var instanceof Variable
+                || !is_string($param->var->name)
+                || $param->type === null
+                || $param->isPromoted()) {
+                continue;
+            }
+
+            $inferred = $this->inferVariableName($param->type);
+            $current = $param->var->name;
+
+            if ($inferred === null || !$this->isAbbreviation($current, $inferred)) {
+                continue;
+            }
+
+            $candidates[] = [
+                'param' => $param,
+                'current' => $current,
+                'inferred' => $inferred,
+            ];
+
+            $inferredNameCounts[ $inferred[ 'name' ] ] = ($inferredNameCounts[ $inferred[ 'name' ] ] ?? 0) + 1;
+
+        }
+
+        foreach ($candidates as $candidate) {
+
+            $current = $candidate[ 'current' ];
+            $inferredName = $candidate[ 'inferred' ][ 'name' ];
+
+            if ($inferredNameCounts[ $inferredName ] > 1
+                || $this->containsVariableNamed($function, $inferredName)
+                || $this->containsConflictingBinding($function, $current)) {
+                continue;
+            }
+
+            $variables = [ $candidate[ 'param' ]->var ];
+
+            if ($function instanceof ArrowFunction) {
+
+                $this->collectBindingVariables($function->expr, $current, $variables);
+
+            } else {
+
+                $this->collectBindingVariables($function->getStmts(), $current, $variables);
+
+            }
+
+            foreach ($variables as $variable) {
+                $this->addEdit($variable, $inferredName, $edits, $conflicts);
+            }
+
+        }
+    }
+
+    /**
+     * @return array{name: string, abbreviations: list<string>}|null
+     */
+    private function inferVariableName(Node $type): ?array
+    {
+        if ($type instanceof NullableType) {
+            return $this->inferVariableName($type->type);
+        }
+
+        if ($type instanceof UnionType || $type instanceof IntersectionType) {
+
+            $inferences = [];
+
+            foreach ($type->types as $memberType) {
+
+                if ($memberType instanceof Identifier && strtolower($memberType->name) === 'null') {
+                    continue;
+                }
+
+                $inference = $this->inferVariableName($memberType);
+
+                if ($inference === null) {
+                    return null;
+                }
+
+                $inferences[] = $inference;
+
+            }
+
+            $names = array_unique(array_column($inferences, 'name'));
+
+            if (count($names) !== 1) {
+                return null;
+            }
+
+            return [
+                'name' => reset($names),
+                'abbreviations' => array_values(array_unique(array_merge(
+                    ...array_column($inferences, 'abbreviations'),
+                ))),
+            ];
+
+        }
+
+        if ($type instanceof Identifier) {
+            return $this->inferFromTypeName($type->name);
+        }
+
+        if (!$type instanceof Name) {
+            return null;
+        }
+
+        $resolvedName = $type->getAttribute('resolvedName');
+        $typeName = $resolvedName instanceof Name ? $resolvedName->toString() : $type->toString();
+
+        return $this->inferFromTypeName($typeName);
+    }
+
+    /**
+     * @return array{name: string, abbreviations: list<string>}|null
+     */
+    private function inferFromTypeName(string $typeName): ?array
+    {
+        $typeNameParts = explode('\\', $typeName);
+        $shortTypeName = end($typeNameParts);
+        $normalizedTypeName = strtolower($shortTypeName);
+
+        if (in_array($normalizedTypeName, self::IGNORED_TYPE_NAMES, true)) {
+            return null;
+        }
+
+        $words = preg_split(
+            '/(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|[_-]+/',
+            $shortTypeName,
+        );
+
+        if ($words === false || $words === []) {
+            return null;
+        }
+
+        while (count($words) > 1 && in_array(strtolower(end($words)), self::TYPE_SUFFIXES, true)) {
+            array_pop($words);
+        }
+
+        $name = strtolower(end($words));
+        $initials = implode('', array_map(
+            static fn (string $word): string => strtolower($word[ 0 ]),
+            $words,
+        ));
+
+        return [
+            'name' => $name,
+            'abbreviations' => [ $initials ],
+        ];
+    }
+
+    /**
+     * @param array{name: string, abbreviations: list<string>} $inferred
+     */
+    private function isAbbreviation(string $current, array $inferred): bool
+    {
+        $current = strtolower($current);
+        $expected = $inferred[ 'name' ];
+
+        if ($current === $expected) {
+            return false;
+        }
+
+        if (strlen($current) === 1 || in_array($current, $inferred[ 'abbreviations' ], true)) {
+            return true;
+        }
+
+        if (strlen($current) >= strlen($expected)) {
+            return false;
+        }
+
+        if (str_starts_with($expected, $current)) {
+            return true;
+        }
+
+        return preg_match('/[aeiou]/', $current) === 0
+            && $this->isOrderedSubsequence($current, $expected);
+    }
+
+    private function isOrderedSubsequence(string $abbreviation, string $word): bool
+    {
+        $abbreviationIndex = 0;
+        $abbreviationLength = strlen($abbreviation);
+
+        for ($wordIndex = 0, $wordLength = strlen($word); $wordIndex < $wordLength; $wordIndex++) {
+
+            if ($word[ $wordIndex ] !== $abbreviation[ $abbreviationIndex ]) {
+                continue;
+            }
+
+            $abbreviationIndex++;
+
+            if ($abbreviationIndex === $abbreviationLength) {
+                return true;
+            }
+
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<Node>|Node|null $node
+     */
+    private function containsVariableNamed(Node|array|null $node, string $name): bool
+    {
+        if ($node instanceof Variable && $node->name === $name) {
+            return true;
+        }
+
+        if (is_array($node)) {
+
+            foreach ($node as $child) {
+
+                if ($this->containsVariableNamed($child, $name)) {
+                    return true;
+                }
+
+            }
+
+            return false;
+
+        }
+
+        if ($node === null) {
+            return false;
+        }
+
+        foreach ($node->getSubNodeNames() as $subNodeName) {
+
+            $subNode = $node->{$subNodeName};
+
+            if (($subNode instanceof Node || is_array($subNode))
+                && $this->containsVariableNamed($subNode, $name)) {
+                return true;
+            }
+
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<Node>|Node|null $node
+     */
+    private function containsConflictingBinding(Node|array|null $node, string $name): bool
+    {
+        if ($node instanceof Catch_ && $node->var?->name === $name) {
+            return true;
+        }
+
+        if ($node instanceof Global_) {
+
+            foreach ($node->vars as $variable) {
+
+                if ($variable->name === $name) {
+                    return true;
+                }
+
+            }
+
+        }
+
+        if ($node instanceof StaticVar && $node->var->name === $name) {
+            return true;
+        }
+
+        if (is_array($node)) {
+
+            foreach ($node as $child) {
+
+                if ($this->containsConflictingBinding($child, $name)) {
+                    return true;
+                }
+
+            }
+
+            return false;
+
+        }
+
+        if ($node === null) {
+            return false;
+        }
+
+        foreach ($node->getSubNodeNames() as $subNodeName) {
+
+            $subNode = $node->{$subNodeName};
+
+            if (($subNode instanceof Node || is_array($subNode))
+                && $this->containsConflictingBinding($subNode, $name)) {
+                return true;
+            }
+
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<Node>|Node|null $node
+     * @param list<Variable> $variables
+     */
+    private function collectBindingVariables(Node|array|null $node, string $name, array &$variables): void
+    {
+        if ($node instanceof Variable && $node->name === $name) {
+
+            $variables[] = $node;
+
+            return;
+
+        }
+
+        if ($node instanceof ArrowFunction) {
+
+            if ($this->functionDeclaresVariable($node, $name)) {
+                return;
+            }
+
+            $this->collectBindingVariables($node->expr, $name, $variables);
+
+            return;
+
+        }
+
+        if ($node instanceof Closure) {
+
+            if ($this->functionDeclaresVariable($node, $name)) {
+                return;
+            }
+
+            foreach ($node->uses as $use) {
+
+                if ($use->var->name !== $name) {
+                    continue;
+                }
+
+                $variables[] = $use->var;
+
+                $this->collectBindingVariables($node->stmts, $name, $variables);
+
+                return;
+
+            }
+
+            return;
+
+        }
+
+        if ($node instanceof Function_ || $node instanceof ClassMethod || $node instanceof ClassLike) {
+            return;
+        }
+
+        if ($node instanceof Catch_ && $node->var?->name === $name) {
+            return;
+        }
+
+        if (is_array($node)) {
+
+            foreach ($node as $child) {
+                $this->collectBindingVariables($child, $name, $variables);
+            }
+
+            return;
+
+        }
+
+        if ($node === null) {
+            return;
+        }
+
+        foreach ($node->getSubNodeNames() as $subNodeName) {
+
+            $subNode = $node->{$subNodeName};
+
+            if ($subNode instanceof Node || is_array($subNode)) {
+                $this->collectBindingVariables($subNode, $name, $variables);
+            }
+
+        }
+    }
+
+    private function functionDeclaresVariable(FunctionLike $function, string $name): bool
+    {
+        foreach ($function->getParams() as $param) {
+
+            if ($param->var instanceof Variable && $param->var->name === $name) {
+                return true;
+            }
+
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int, array{end: int, replacement: string}> $edits
+     * @param array<int, true> $conflicts
+     */
+    private function addEdit(Variable $variable, string $name, array &$edits, array &$conflicts): void
+    {
+        $start = $variable->getStartFilePos();
+        $end = $variable->getEndFilePos();
+
+        if ($start < 0 || $end < $start || isset($conflicts[ $start ])) {
+            return;
+        }
+
+        $replacement = sprintf('$%s', $name);
+
+        if (isset($edits[ $start ]) && $edits[ $start ][ 'replacement' ] !== $replacement) {
+
+            unset($edits[ $start ]);
+
+            $conflicts[ $start ] = true;
+
+            return;
+
+        }
+
+        $edits[ $start ] = [
+            'end' => $end,
+            'replacement' => $replacement,
+        ];
+    }
+}

--- a/tests/DescriptiveVariableNameFixerTest.php
+++ b/tests/DescriptiveVariableNameFixerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests;
+
+use DigitalCreative\ECS\Tests\Support\EcsTestCase;
+
+final class DescriptiveVariableNameFixerTest extends EcsTestCase
+{
+    public function test_single_letters_and_type_related_abbreviations_are_replaced(): void
+    {
+        $fixtureDirectory = __DIR__ . '/Fixtures/DescriptiveVariableNameFixer';
+
+        $this->assertFixtureIsFixedTo(
+            $fixtureDirectory . '/Before/ArrowFunctions.php',
+            $fixtureDirectory . '/After/ArrowFunctions.php',
+        );
+    }
+
+    public function test_references_are_renamed_without_crossing_nested_scope_boundaries(): void
+    {
+        $fixtureDirectory = __DIR__ . '/Fixtures/DescriptiveVariableNameFixer';
+
+        $this->assertFixtureIsFixedTo(
+            $fixtureDirectory . '/Before/ClosureScopes.php',
+            $fixtureDirectory . '/After/ClosureScopes.php',
+        );
+    }
+
+    public function test_names_are_inferred_from_nullable_union_builtin_and_qualified_types(): void
+    {
+        $fixtureDirectory = __DIR__ . '/Fixtures/DescriptiveVariableNameFixer';
+
+        $this->assertFixtureIsFixedTo(
+            $fixtureDirectory . '/Before/TypeInference.php',
+            $fixtureDirectory . '/After/TypeInference.php',
+        );
+    }
+
+    public function test_ambiguous_or_unsupported_variables_remain_unchanged(): void
+    {
+        $this->assertFixturePasses(
+            __DIR__ . '/Fixtures/DescriptiveVariableNameFixer/Valid/UncertainVariables.php',
+        );
+    }
+}

--- a/tests/Fixtures/DescriptiveVariableNameFixer/After/ArrowFunctions.php
+++ b/tests/Fixtures/DescriptiveVariableNameFixer/After/ArrowFunctions.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\DescriptiveVariableNameFixer;
+
+use Vendor\Permissions\McpPromptPermission as PromptPermissionAlias;
+use Vendor\Permissions\McpResourcePermission;
+use Vendor\Permissions\McpToolPermission;
+
+final class ArrowFunctions
+{
+    public function abilities(): array
+    {
+        return [
+            ...array_map(static fn (McpResourcePermission $permission): string => $permission->ability(), McpResourcePermission::cases()),
+            ...array_map(static fn (McpToolPermission $permission): string => $permission->ability(), McpToolPermission::cases()),
+            ...array_map(static fn (McpResourcePermission $permission): string => $permission->ability(), McpResourcePermission::cases()),
+            ...array_map(static fn (PromptPermissionAlias $permission): string => $permission->ability(), PromptPermissionAlias::cases()),
+        ];
+    }
+}

--- a/tests/Fixtures/DescriptiveVariableNameFixer/After/ClosureScopes.php
+++ b/tests/Fixtures/DescriptiveVariableNameFixer/After/ClosureScopes.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\DescriptiveVariableNameFixer;
+
+use Closure;
+use Vendor\Permissions\McpResourcePermission;
+use Vendor\Permissions\McpToolPermission;
+
+final class ClosureScopes
+{
+    public function callbacks(): array
+    {
+        $capturedByClosure = static function (McpResourcePermission &$permission): Closure {
+
+            return static function () use (&$permission): string {
+                return $permission->ability();
+            };
+
+        };
+
+        $capturedByArrow = static fn (McpResourcePermission $permission): Closure => static fn (): string => $permission->ability();
+        $shadowed = static fn (McpResourcePermission $permission): Closure => static fn (McpToolPermission $permission): string => $permission->ability();
+
+        return [ $capturedByClosure, $capturedByArrow, $shadowed ];
+    }
+}

--- a/tests/Fixtures/DescriptiveVariableNameFixer/After/TypeInference.php
+++ b/tests/Fixtures/DescriptiveVariableNameFixer/After/TypeInference.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\DescriptiveVariableNameFixer;
+
+use Vendor\Permissions\McpResourcePermission;
+use Vendor\Permissions\McpToolPermission;
+use Vendor\Repositories\PermissionRepositoryInterface;
+
+final class TypeInference
+{
+    public function namedFunctionParameter(PermissionRepositoryInterface $repository): object
+    {
+        return $repository;
+    }
+
+    public function callbacks(): array
+    {
+        $nullable = static fn (?McpResourcePermission $permission): string => $permission?->ability() ?? '';
+        $union = static fn (McpResourcePermission|McpToolPermission $permission): string => $permission->ability();
+        $intersection = static fn (PermissionRepositoryInterface $repository): object => $repository;
+        $fullyQualified = static fn (McpResourcePermission $permission): string => $permission->ability();
+        $string = static fn (string $string): string => $string;
+        $callable = static fn (callable $callable): callable => $callable;
+
+        return [ $nullable, $union, $intersection, $fullyQualified, $string, $callable ];
+    }
+}

--- a/tests/Fixtures/DescriptiveVariableNameFixer/Before/ArrowFunctions.php
+++ b/tests/Fixtures/DescriptiveVariableNameFixer/Before/ArrowFunctions.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\DescriptiveVariableNameFixer;
+
+use Vendor\Permissions\McpPromptPermission as PromptPermissionAlias;
+use Vendor\Permissions\McpResourcePermission;
+use Vendor\Permissions\McpToolPermission;
+
+final class ArrowFunctions
+{
+    public function abilities(): array
+    {
+        return [
+            ...array_map(static fn (McpResourcePermission $p): string => $p->ability(), McpResourcePermission::cases()),
+            ...array_map(static fn (McpToolPermission $perm): string => $perm->ability(), McpToolPermission::cases()),
+            ...array_map(static fn (McpResourcePermission $prm): string => $prm->ability(), McpResourcePermission::cases()),
+            ...array_map(static fn (PromptPermissionAlias $mpp): string => $mpp->ability(), PromptPermissionAlias::cases()),
+        ];
+    }
+}

--- a/tests/Fixtures/DescriptiveVariableNameFixer/Before/ClosureScopes.php
+++ b/tests/Fixtures/DescriptiveVariableNameFixer/Before/ClosureScopes.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\DescriptiveVariableNameFixer;
+
+use Closure;
+use Vendor\Permissions\McpResourcePermission;
+use Vendor\Permissions\McpToolPermission;
+
+final class ClosureScopes
+{
+    public function callbacks(): array
+    {
+        $capturedByClosure = static function (McpResourcePermission &$p): Closure {
+
+            return static function () use (&$p): string {
+                return $p->ability();
+            };
+
+        };
+
+        $capturedByArrow = static fn (McpResourcePermission $p): Closure => static fn (): string => $p->ability();
+        $shadowed = static fn (McpResourcePermission $p): Closure => static fn (McpToolPermission $p): string => $p->ability();
+
+        return [ $capturedByClosure, $capturedByArrow, $shadowed ];
+    }
+}

--- a/tests/Fixtures/DescriptiveVariableNameFixer/Before/TypeInference.php
+++ b/tests/Fixtures/DescriptiveVariableNameFixer/Before/TypeInference.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\DescriptiveVariableNameFixer;
+
+use Vendor\Permissions\McpResourcePermission;
+use Vendor\Permissions\McpToolPermission;
+use Vendor\Repositories\PermissionRepositoryInterface;
+
+final class TypeInference
+{
+    public function namedFunctionParameter(PermissionRepositoryInterface $pr): object
+    {
+        return $pr;
+    }
+
+    public function callbacks(): array
+    {
+        $nullable = static fn (?McpResourcePermission $p): string => $p?->ability() ?? '';
+        $union = static fn (McpResourcePermission | McpToolPermission $perm): string => $perm->ability();
+        $intersection = static fn (PermissionRepositoryInterface $pr): object => $pr;
+        $fullyQualified = static fn (\Vendor\Permissions\McpResourcePermission $x): string => $x->ability();
+        $string = static fn (string $str): string => $str;
+        $callable = static fn (callable $cb): callable => $cb;
+
+        return [ $nullable, $union, $intersection, $fullyQualified, $string, $callable ];
+    }
+}

--- a/tests/Fixtures/DescriptiveVariableNameFixer/Valid/UncertainVariables.php
+++ b/tests/Fixtures/DescriptiveVariableNameFixer/Valid/UncertainVariables.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\DescriptiveVariableNameFixer;
+
+use Vendor\Permissions\McpResourcePermission;
+use Vendor\Permissions\McpToolPermission;
+use Vendor\Permissions\Permission;
+use Vendor\Tools\Tool;
+
+final class UncertainVariables
+{
+    public function __construct(
+        public readonly Permission $p,
+    )
+    {
+    }
+
+    public function callbacks(Permission $permission): array
+    {
+        $ambiguousUnion = static fn (Permission|Tool $p): object => $p;
+        $nameCollision = static fn (Permission $p): string => sprintf('%s:%s', $permission->name(), $p->name());
+        $duplicateInference = static fn (McpResourcePermission $p, McpToolPermission $t): string => sprintf('%s:%s', $p->ability(), $t->ability());
+        $alreadyDescriptive = static fn (Permission $resourcePermission): string => $resourcePermission->name();
+        $unrelatedName = static fn (Permission $value): string => $value->name();
+        $unknownType = static fn (self $s): self => $s;
+
+        return [
+            $ambiguousUnion,
+            $nameCollision,
+            $duplicateInference,
+            $alreadyDescriptive,
+            $unrelatedName,
+            $unknownType,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add a risky custom fixer that renames typed function parameters and their scope-bound references from single letters or type-related abbreviations
- infer names from resolved class names, nullable/compatible union and intersection types, built-in types, and common `Interface`/`Contract` suffixes
- recognize exact initials, prefixes, and consonant-only ordered abbreviations without a broad English dictionary that could misclassify domain vocabulary
- skip ambiguous types, name collisions, duplicate inferred names, promoted properties, and conflicting catch/global/static bindings
- register the fixer and declare `nikic/php-parser` as a runtime dependency

## Verification
- `php vendor/bin/phpunit --do-not-cache-result tests/DescriptiveVariableNameFixerTest.php` — 4 tests, 8 assertions passed on PHP 8.4.23
- targeted `ecs check ... --config src/Custom.php` — clean
- `composer validate --no-check-publish --no-check-lock` — valid (existing missing-license warning only)
- end-to-end ECS smoke test changed both callback `$p` declarations and references in the supplied abilities example to `$permission`
- full `phpunit tests` run: 18 tests passed; 10 unrelated existing fixture assertions failed only because this checkout converts tracked expected fixtures to CRLF while ECS emits LF
