### PR TITLE
Ban switch statements in favor of match

### DIFF
--- a/src/Custom.php
+++ b/src/Custom.php
@@ -16,6 +16,7 @@ use DigitalCreative\ECS\Fixers\PaddedBlockFixer;
 use DigitalCreative\ECS\Fixers\PaddedMultilineStatementFixer;
 use DigitalCreative\ECS\Fixers\StatementGroupingFixer;
 use DigitalCreative\ECS\Fixers\TraitUseSpacingFixer;
+use DigitalCreative\ECS\Sniffs\ForbidSwitchStatementSniff;
 use DigitalCreative\ECS\Sniffs\RequireParameterTypeSniff;
 
 return register_fixers(fixers: [
@@ -30,6 +31,7 @@ return register_fixers(fixers: [
     DescriptiveVariableNameFixer::class => true,
     FunctionParameterLayoutFixer::class => true,
     MultilineNamedArgumentsFixer::class => true,
+    ForbidSwitchStatementSniff::class => true,
     RequireParameterTypeSniff::class => true,
     LaravelEmptyToBlankFixer::class => true,
 ])->withSets([

--- a/src/Sniffs/ForbidSwitchStatementSniff.php
+++ b/src/Sniffs/ForbidSwitchStatementSniff.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Sniffs;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+final class ForbidSwitchStatementSniff implements Sniff
+{
+    private const string ERROR_MESSAGE = 'Switch statements are forbidden. Use a match expression instead.';
+
+    public function register(): array
+    {
+        return [ T_SWITCH ];
+    }
+
+    public function process(File $phpcsFile, int $stackPtr): void
+    {
+        $phpcsFile->addError(
+            error: self::ERROR_MESSAGE,
+            stackPtr: $stackPtr,
+            code: 'Found',
+        );
+    }
+}

--- a/tests/Fixtures/ForbidSwitchStatement/match_expression.php
+++ b/tests/Fixtures/ForbidSwitchStatement/match_expression.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types = 1);
+
+$result = match ($outcome) {
+    RequestedPaymentOutcome::Recorded => $deliveries->markRecorded($delivery),
+    RequestedPaymentOutcome::Skipped => $deliveries->release($delivery),
+};

--- a/tests/Fixtures/ForbidSwitchStatement/switch_statements.php
+++ b/tests/Fixtures/ForbidSwitchStatement/switch_statements.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types = 1);
+
+switch ($outcome) {
+    case RequestedPaymentOutcome::Recorded:
+        $deliveries->markRecorded($delivery);
+
+        break;
+    case RequestedPaymentOutcome::Skipped:
+        $deliveries->release($delivery);
+
+        break;
+}
+
+switch ($outcome):
+    case RequestedPaymentOutcome::Recorded:
+        $description = 'recorded';
+
+        break;
+    default:
+        $description = 'skipped';
+
+        break;
+endswitch;

--- a/tests/Rules/ForbidSwitchStatementSniffTest.php
+++ b/tests/Rules/ForbidSwitchStatementSniffTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Rules;
+
+use DigitalCreative\ECS\Tests\Support\EcsTestCase;
+use Symplify\EasyCodingStandard\SniffRunner\Application\SniffFileProcessor;
+use Symplify\EasyCodingStandard\SniffRunner\DataCollector\SniffMetadataCollector;
+use Symplify\EasyCodingStandard\SniffRunner\ValueObject\Error\CodingStandardError;
+
+final class ForbidSwitchStatementSniffTest extends EcsTestCase
+{
+    private const string ERROR_MESSAGE = 'Switch statements are forbidden. Use a match expression instead.';
+
+    public function provideConfig(): string
+    {
+        return __DIR__ . '/../Support/ForbidSwitchStatement.php';
+    }
+
+    public function test_reports_every_switch_syntax_with_match_guidance(): void
+    {
+        $errors = $this->processFixture(
+            __DIR__ . '/../Fixtures/ForbidSwitchStatement/switch_statements.php',
+        );
+
+        self::assertCount(2, $errors);
+
+        foreach ($errors as $error) {
+            self::assertSame(self::ERROR_MESSAGE, $error->getMessage());
+        }
+    }
+
+    public function test_accepts_match_expressions(): void
+    {
+        self::assertSame([], $this->processFixture(
+            __DIR__ . '/../Fixtures/ForbidSwitchStatement/match_expression.php',
+        ));
+    }
+
+    /**
+     * @return list<CodingStandardError>
+     */
+    private function processFixture(string $fixture): array
+    {
+        $sniffFileProcessor = $this->make(SniffFileProcessor::class);
+        $sniffMetadataCollector = $this->make(SniffMetadataCollector::class);
+
+        self::assertNotEmpty($sniffFileProcessor->getCheckers(), 'The ECS configuration registered no sniffs.');
+
+        $sniffMetadataCollector->reset();
+
+        $sniffFileProcessor->processFileToString($fixture);
+
+        return $sniffMetadataCollector->getCodingStandardErrors();
+    }
+}

--- a/tests/Support/ForbidSwitchStatement.php
+++ b/tests/Support/ForbidSwitchStatement.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types = 1);
+
+use DigitalCreative\ECS\Sniffs\ForbidSwitchStatementSniff;
+
+return register_fixers([
+    ForbidSwitchStatementSniff::class => true,
+]);


### PR DESCRIPTION
## Summary
- add `ForbidSwitchStatementSniff` and enable it in the shared ECS configuration
- report every `switch` token with guidance to use a `match` expression
- cover brace syntax, alternative syntax, and accepted `match` expressions with native PHP fixtures

## Verification
- `php vendor/bin/phpunit --do-not-cache-result tests/Rules/ForbidSwitchStatementSniffTest.php` — 2 tests, 6 assertions passed
- ECS check of the new sniff, test, support config, and valid fixture — passed
- ECS smoke check of the forbidden fixture — reported both switch statements with `ForbidSwitchStatementSniff.Found`
- Full suite on the Linux container: 5 tests passed and 40 existing fixer-fixture assertions failed only because the checkout uses CRLF while generated output uses LF (`core.autocrlf=true`); the new focused tests pass
