### PR TITLE
Format new-object calls inside Pest closures

### DIFF
--- a/src/Fixers/MultilineNamedArgumentsFixer.php
+++ b/src/Fixers/MultilineNamedArgumentsFixer.php
@@ -713,14 +713,9 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
 
             $receiver = $tokens->getPrevMeaningfulToken($beforeName);
 
-            if ($receiver === null
-                || $tokens[ $receiver ]->isGivenKind(T_VARIABLE) === false
-                || $tokens[ $receiver ]->getContent() !== '$this'
-                || $classIndex === null) {
-                return null;
-            }
-
-            return $this->resolveSourceMethod($classIndex, $name);
+            return $receiver === null
+                ? null
+                : $this->resolveObjectMethod($tokens, $receiver, $openParenthesis, $classIndex, $name);
 
         }
 
@@ -778,6 +773,62 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
         }
 
         return $this->resolveFunction($name, $openParenthesis);
+    }
+
+    /**
+     * @return list<array{name: string, variadic: bool}>|null
+     */
+    private function resolveObjectMethod(Tokens $tokens, int $receiver, int $position, ?int $classIndex, string $method): ?array
+    {
+        if ($tokens[ $receiver ]->isGivenKind(T_VARIABLE)) {
+
+            if ($tokens[ $receiver ]->getContent() !== '$this' || $classIndex === null) {
+                return null;
+            }
+
+            return $this->resolveSourceMethod($classIndex, $method);
+
+        }
+
+        if ($tokens[ $receiver ]->equals(')') === false) {
+            return null;
+        }
+
+        $constructorParenthesis = $tokens->findBlockStart(
+            Tokens::BLOCK_TYPE_PARENTHESIS_BRACE,
+            $receiver,
+        );
+
+        $classNameIndex = $tokens->getPrevMeaningfulToken($constructorParenthesis);
+
+        if ($classNameIndex === null || $this->isNameToken($tokens[ $classNameIndex ]) === false) {
+            return null;
+        }
+
+        $classIdentifier = $this->readQualifiedNameEndingAt($tokens, $classNameIndex);
+        $newIndex = $tokens->getPrevMeaningfulToken($classIdentifier[ 'start' ]);
+
+        if ($newIndex === null || $tokens[ $newIndex ]->isGivenKind(T_NEW) === false) {
+            return null;
+        }
+
+        $normalizedIdentifier = strtolower($classIdentifier[ 'name' ]);
+
+        if (($normalizedIdentifier === 'self' || $normalizedIdentifier === 'static') && $classIndex !== null) {
+            return $this->resolveSourceMethod($classIndex, $method);
+        }
+
+        if ($normalizedIdentifier === 'parent' && $classIndex !== null) {
+
+            $parent = $this->classes[ $classIndex ][ 'parent' ];
+
+            return $parent === null ? null : $this->resolveMethod($parent, $method);
+
+        }
+
+        $className = $this->resolveClassIdentifier($classIdentifier[ 'name' ], $position);
+
+        return $className === null ? null : $this->resolveMethod($className, $method);
     }
 
     /**
@@ -909,7 +960,7 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
                 return null;
             }
 
-            $constructor = (new ReflectionClass($className))->getConstructor();
+            $constructor = new ReflectionClass($className)->getConstructor();
 
             return $constructor === null ? null : $this->reflectionParameters($constructor->getParameters());
 
@@ -931,7 +982,7 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
                 return null;
             }
 
-            return $this->reflectionParameters((new ReflectionFunction($name))->getParameters());
+            return $this->reflectionParameters(new ReflectionFunction($name)->getParameters());
 
         } catch (Throwable) {
 

--- a/src/Fixers/StatementGroupingFixer.php
+++ b/src/Fixers/StatementGroupingFixer.php
@@ -20,8 +20,8 @@ final class StatementGroupingFixer extends AbstractFixer implements WhitespacesA
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'Adds blank lines between adjacent expression statements with different receivers or call types without removing existing separation.',
-            [],
+            summary: 'Adds blank lines between adjacent expression statements with different receivers or call types without removing existing separation.',
+            codeSamples: [],
         );
     }
 
@@ -38,11 +38,26 @@ final class StatementGroupingFixer extends AbstractFixer implements WhitespacesA
     protected function applyFix(SplFileInfo $file, Tokens $tokens): void
     {
         $statements = $this->findGroupableStatements($tokens);
+        $previousByScope = [];
+        $statementPairs = [];
 
-        for ($index = count($statements) - 1; $index > 0; $index--) {
+        foreach ($statements as $statement) {
 
-            $previous = $statements[ $index - 1 ];
-            $current = $statements[ $index ];
+            $scope = $statement[ 'scope' ];
+            $previous = $previousByScope[ $scope ] ?? null;
+
+            if ($previous !== null) {
+                $statementPairs[] = [ 'previous' => $previous, 'current' => $statement ];
+            }
+
+            $previousByScope[ $scope ] = $statement;
+
+        }
+
+        for ($index = count($statementPairs) - 1; $index >= 0; $index--) {
+
+            $previous = $statementPairs[ $index ][ 'previous' ];
+            $current = $statementPairs[ $index ][ 'current' ];
 
             if ($this->containsOnlyWhitespace($tokens, $previous[ 'end' ], $current[ 'start' ]) === false) {
                 continue;
@@ -53,29 +68,52 @@ final class StatementGroupingFixer extends AbstractFixer implements WhitespacesA
             }
 
             $this->ensureBlankLineBetween(
-                $tokens,
-                $previous[ 'end' ],
-                $current[ 'start' ],
+                tokens: $tokens,
+                previousEnd: $previous[ 'end' ],
+                currentStart: $current[ 'start' ],
             );
 
         }
     }
 
     /**
-     * @return list<array{start: int, end: int, kind: string, receiver: ?string, multiline: bool}>
+     * @return list<array{start: int, end: int, kind: string, receiver: ?string, multiline: bool, scope: int}>
      */
     private function findGroupableStatements(Tokens $tokens): array
     {
         $statements = [];
         $nestedExpressionDepth = 0;
+        $enclosingExpressionDepths = [];
+        $scopeStack = [ 0 ];
+        $nextScope = 1;
 
         foreach ($tokens as $index => $token) {
 
             $block = Tokens::detectBlockType($token);
 
-            if ($block !== null && $this->isExpressionBlock($block[ 'type' ])) {
+            if ($block !== null) {
 
-                $nestedExpressionDepth += $block[ 'isStart' ] ? 1 : -1;
+                if ($this->isExpressionBlock($block[ 'type' ])) {
+
+                    $nestedExpressionDepth += $block[ 'isStart' ] ? 1 : -1;
+
+                    continue;
+
+                }
+
+                if ($block[ 'isStart' ]) {
+
+                    $enclosingExpressionDepths[] = $nestedExpressionDepth;
+                    $nestedExpressionDepth = 0;
+                    $scopeStack[] = $nextScope++;
+
+                } else {
+
+                    $nestedExpressionDepth = array_pop($enclosingExpressionDepths) ?? 0;
+
+                    array_pop($scopeStack);
+
+                }
 
                 continue;
 
@@ -103,6 +141,7 @@ final class StatementGroupingFixer extends AbstractFixer implements WhitespacesA
                 'kind' => $group[ 'kind' ],
                 'receiver' => $group[ 'receiver' ],
                 'multiline' => $tokens->isPartialCodeMultiline($start, $index),
+                'scope' => $scopeStack[ count($scopeStack) - 1 ],
             ];
 
         }
@@ -208,6 +247,23 @@ final class StatementGroupingFixer extends AbstractFixer implements WhitespacesA
 
         if ($next === null) {
             return null;
+        }
+
+        if ($token->isGivenKind(T_NEW)) {
+
+            $className = $tokens[ $next ]->isGivenKind([
+                T_STRING,
+                T_NAME_QUALIFIED,
+                T_NAME_FULLY_QUALIFIED,
+                T_NAME_RELATIVE,
+                T_STATIC,
+            ]) ? $tokens[ $next ]->getContent() : null;
+
+            return [
+                'kind' => 'new-object-call',
+                'receiver' => $className,
+            ];
+
         }
 
         if ($tokens[ $next ]->isGivenKind(T_DOUBLE_COLON)) {

--- a/tests/Fixtures/MultilineNamedArgumentsFixer/After/PestValidation.php
+++ b/tests/Fixtures/MultilineNamedArgumentsFixer/After/PestValidation.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\MultilineNamedArgumentsFixer;
+
+use Closure;
+
+final class PestValidation
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+    }
+}
+
+test('test_analytics_metadata_rejects_excessive_nesting', function (): void {
+
+    $value = 'safe';
+
+    for ($depth = 0; $depth < 7; $depth++) {
+        $value = [ 'level' => $value ];
+    }
+
+    $messages = [];
+
+    new PestValidation()->validate(
+        attribute: 'metadata',
+        value: $value,
+        fail: static function (string $message) use (&$messages): void {
+            $messages[] = $message;
+        },
+    );
+
+});

--- a/tests/Fixtures/MultilineNamedArgumentsFixer/Before/PestValidation.php
+++ b/tests/Fixtures/MultilineNamedArgumentsFixer/Before/PestValidation.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\MultilineNamedArgumentsFixer;
+
+use Closure;
+
+final class PestValidation
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+    }
+}
+
+test('test_analytics_metadata_rejects_excessive_nesting', function (): void {
+
+    $value = 'safe';
+
+    for ($depth = 0; $depth < 7; $depth++) {
+        $value = [ 'level' => $value ];
+    }
+
+    $messages = [];
+
+    new PestValidation()->validate(
+        'metadata',
+        $value,
+        static function (string $message) use (&$messages): void {
+            $messages[] = $message;
+        },
+    );
+
+});

--- a/tests/Fixtures/StatementGroupingFixer/After/PestValidation.php
+++ b/tests/Fixtures/StatementGroupingFixer/After/PestValidation.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\StatementGroupingFixer;
+
+use Closure;
+
+final class PestValidation
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+    }
+}
+
+test('test_analytics_metadata_rejects_excessive_nesting', function (): void {
+
+    $value = 'safe';
+
+    for ($depth = 0; $depth < 7; $depth++) {
+        $value = [ 'level' => $value ];
+    }
+
+    $messages = [];
+
+    new PestValidation()->validate(
+        attribute: 'metadata',
+        value: $value,
+        fail: static function (string $message) use (&$messages): void {
+            $messages[] = $message;
+        },
+    );
+
+});

--- a/tests/Fixtures/StatementGroupingFixer/Before/PestValidation.php
+++ b/tests/Fixtures/StatementGroupingFixer/Before/PestValidation.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\StatementGroupingFixer;
+
+use Closure;
+
+final class PestValidation
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+    }
+}
+
+test('test_analytics_metadata_rejects_excessive_nesting', function (): void {
+
+    $value = 'safe';
+
+    for ($depth = 0; $depth < 7; $depth++) {
+        $value = [ 'level' => $value ];
+    }
+
+    $messages = [];
+    new PestValidation()->validate(
+        attribute: 'metadata',
+        value: $value,
+        fail: static function (string $message) use (&$messages): void {
+            $messages[] = $message;
+        },
+    );
+
+});

--- a/tests/MultilineNamedArgumentsFixerTest.php
+++ b/tests/MultilineNamedArgumentsFixerTest.php
@@ -18,6 +18,16 @@ final class MultilineNamedArgumentsFixerTest extends EcsTestCase
         );
     }
 
+    public function test_methods_called_on_new_objects_use_resolved_parameter_names(): void
+    {
+        $fixtureDirectory = __DIR__ . '/Fixtures/MultilineNamedArgumentsFixer';
+
+        $this->assertFixtureIsFixedTo(
+            inputFixture: $fixtureDirectory . '/Before/PestValidation.php',
+            expectedFixture: $fixtureDirectory . '/After/PestValidation.php',
+        );
+    }
+
     public function test_namespace_alias_and_source_inheritance_are_resolved(): void
     {
         $fixtureDirectory = __DIR__ . '/Fixtures/MultilineNamedArgumentsFixer';

--- a/tests/StatementGroupingFixerTest.php
+++ b/tests/StatementGroupingFixerTest.php
@@ -13,8 +13,18 @@ final class StatementGroupingFixerTest extends EcsTestCase
         $fixtureDirectory = __DIR__ . '/Fixtures/StatementGroupingFixer';
 
         $this->assertFixtureIsFixedTo(
-            $fixtureDirectory . '/Before/OrderWorkflow.php',
-            $fixtureDirectory . '/After/OrderWorkflow.php',
+            inputFixture: $fixtureDirectory . '/Before/OrderWorkflow.php',
+            expectedFixture: $fixtureDirectory . '/After/OrderWorkflow.php',
+        );
+    }
+
+    public function test_groups_new_object_calls_inside_pest_closures(): void
+    {
+        $fixtureDirectory = __DIR__ . '/Fixtures/StatementGroupingFixer';
+
+        $this->assertFixtureIsFixedTo(
+            inputFixture: $fixtureDirectory . '/Before/PestValidation.php',
+            expectedFixture: $fixtureDirectory . '/After/PestValidation.php',
         );
     }
 
@@ -23,8 +33,8 @@ final class StatementGroupingFixerTest extends EcsTestCase
         $fixtureDirectory = __DIR__ . '/Fixtures/StatementGroupingFixer';
 
         $this->assertFixtureIsFixedTo(
-            $fixtureDirectory . '/Before/CampaignWorkflow.php',
-            $fixtureDirectory . '/After/CampaignWorkflow.php',
+            inputFixture: $fixtureDirectory . '/Before/CampaignWorkflow.php',
+            expectedFixture: $fixtureDirectory . '/After/CampaignWorkflow.php',
         );
     }
 
@@ -33,8 +43,8 @@ final class StatementGroupingFixerTest extends EcsTestCase
         $fixtureDirectory = __DIR__ . '/Fixtures/StatementGroupingFixer';
 
         $this->assertFixtureIsFixedTo(
-            $fixtureDirectory . '/Before/MultilineWorkflow.php',
-            $fixtureDirectory . '/After/MultilineWorkflow.php',
+            inputFixture: $fixtureDirectory . '/Before/MultilineWorkflow.php',
+            expectedFixture: $fixtureDirectory . '/After/MultilineWorkflow.php',
         );
     }
 
@@ -43,8 +53,8 @@ final class StatementGroupingFixerTest extends EcsTestCase
         $fixtureDirectory = __DIR__ . '/Fixtures/StatementGroupingFixer';
 
         $this->assertFixtureIsFixedTo(
-            $fixtureDirectory . '/Before/AssignmentAndProperties.php',
-            $fixtureDirectory . '/After/AssignmentAndProperties.php',
+            inputFixture: $fixtureDirectory . '/Before/AssignmentAndProperties.php',
+            expectedFixture: $fixtureDirectory . '/After/AssignmentAndProperties.php',
         );
     }
 
@@ -53,8 +63,8 @@ final class StatementGroupingFixerTest extends EcsTestCase
         $fixtureDirectory = __DIR__ . '/Fixtures/StatementGroupingFixer';
 
         $this->assertFixtureIsFixedTo(
-            $fixtureDirectory . '/Before/AdditiveGrouping.php',
-            $fixtureDirectory . '/After/AdditiveGrouping.php',
+            inputFixture: $fixtureDirectory . '/Before/AdditiveGrouping.php',
+            expectedFixture: $fixtureDirectory . '/After/AdditiveGrouping.php',
         );
     }
 


### PR DESCRIPTION
## Summary
- resolve method parameters for multiline calls whose receiver is a freshly constructed object, including source classes and `self`/`static`/`parent` resolution
- track statement groups by brace scope so Pest closure bodies are formatted independently from the enclosing `test(...)` call
- classify `new Class()->method()` statements by their constructed class so unrelated assignments receive a separating blank line
- add Pest-style before/after fixtures for named arguments and statement separation

## Verification
- `php vendor/bin/phpunit --do-not-cache-result tests` — 47 tests, 103 assertions passed
- focused affected test classes — 13 tests, 26 assertions passed
- new Pest regressions — 2 tests, 4 assertions passed
- ECS check of both changed fixers, tests, and expected fixtures — passed
- behavioral reproduction now produces `attribute:`, `value:`, and `fail:` names plus a blank line before `new NonSensitiveEventMetadata()->validate(...)`
