### PR TITLE
Resolve named arguments for typed parameter receivers

### DIFF
--- a/src/Fixers/MultilineNamedArgumentsFixer.php
+++ b/src/Fixers/MultilineNamedArgumentsFixer.php
@@ -50,6 +50,11 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
      */
     private array $functions = [];
 
+    /**
+     * @var list<array{start: int, end: int, openParenthesis: int, closeParenthesis: int}>
+     */
+    private array $callableScopes = [];
+
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
@@ -80,6 +85,7 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
         $this->namespaceContexts = $this->collectNamespaceContexts($tokens);
         $this->classes = $this->collectClassScopes($tokens);
         $this->functions = [];
+        $this->callableScopes = $this->collectCallableScopes($tokens);
 
         $this->collectImports($tokens);
         $this->resolveClassNames();
@@ -99,8 +105,8 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
 
             $openParenthesis = $openParentheses[ $index ];
             $closeParenthesis = $tokens->findBlockEnd(
-                Tokens::BLOCK_TYPE_PARENTHESIS_BRACE,
-                $openParenthesis,
+                type: Tokens::BLOCK_TYPE_PARENTHESIS_BRACE,
+                searchIndex: $openParenthesis,
             );
 
             if ($tokens->isPartialCodeMultiline($openParenthesis, $closeParenthesis) === false) {
@@ -446,8 +452,8 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
             }
 
             $closeParenthesis = $tokens->findBlockEnd(
-                Tokens::BLOCK_TYPE_PARENTHESIS_BRACE,
-                $openParenthesis,
+                type: Tokens::BLOCK_TYPE_PARENTHESIS_BRACE,
+                searchIndex: $openParenthesis,
             );
 
             $parameters = $this->readDeclaredParameters(
@@ -476,6 +482,48 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
             $this->functions[ $functionName ] = $parameters;
 
         }
+    }
+
+    /**
+     * @return list<array{start: int, end: int, openParenthesis: int, closeParenthesis: int}>
+     */
+    private function collectCallableScopes(Tokens $tokens): array
+    {
+        $scopes = [];
+
+        for ($index = 0; $index < $tokens->count(); $index++) {
+
+            if ($tokens[ $index ]->isGivenKind(T_FUNCTION) === false) {
+                continue;
+            }
+
+            $openParenthesis = $tokens->getNextTokenOfKind($index, [ '(' ]);
+
+            if ($openParenthesis === null) {
+                continue;
+            }
+
+            $closeParenthesis = $tokens->findBlockEnd(
+                type: Tokens::BLOCK_TYPE_PARENTHESIS_BRACE,
+                searchIndex: $openParenthesis,
+            );
+
+            $bodyStart = $tokens->getNextTokenOfKind($closeParenthesis, [ '{', ';' ]);
+
+            if ($bodyStart === null || $tokens[ $bodyStart ]->equals('{') === false) {
+                continue;
+            }
+
+            $scopes[] = [
+                'start' => $bodyStart,
+                'end' => $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $bodyStart),
+                'openParenthesis' => $openParenthesis,
+                'closeParenthesis' => $closeParenthesis,
+            ];
+
+        }
+
+        return $scopes;
     }
 
     private function findFunctionName(Tokens $tokens, int $functionIndex): ?int
@@ -662,8 +710,8 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
         }
 
         return $tokens->isPartialCodeMultiline(
-            $openParenthesis,
-            $arguments[ 0 ][ 'start' ] - 1,
+            start: $openParenthesis,
+            end: $arguments[ 0 ][ 'start' ] - 1,
         );
     }
 
@@ -820,14 +868,10 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
      */
     private function resolveObjectMethod(Tokens $tokens, int $receiver, int $position, ?int $classIndex, string $method): ?array
     {
-        if ($tokens[ $receiver ]->isGivenKind(T_VARIABLE)) {
-
-            if ($tokens[ $receiver ]->getContent() !== '$this' || $classIndex === null) {
-                return null;
-            }
-
+        if ($tokens[ $receiver ]->isGivenKind(T_VARIABLE)
+            && $tokens[ $receiver ]->getContent() === '$this'
+            && $classIndex !== null) {
             return $this->resolveSourceMethod($classIndex, $method);
-
         }
 
         $className = $this->resolveReceiverClass($tokens, $receiver, $position, $classIndex);
@@ -839,11 +883,16 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
     {
         if ($tokens[ $receiver ]->isGivenKind(T_VARIABLE)) {
 
-            if ($tokens[ $receiver ]->getContent() !== '$this' || $classIndex === null) {
-                return null;
+            if ($tokens[ $receiver ]->getContent() === '$this') {
+                return $classIndex === null ? null : $this->classes[ $classIndex ][ 'name' ];
             }
 
-            return $this->classes[ $classIndex ][ 'name' ];
+            return $this->resolveSourceParameterClass(
+                tokens: $tokens,
+                position: $position,
+                variable: $tokens[ $receiver ]->getContent(),
+                classIndex: $classIndex,
+            );
 
         }
 
@@ -856,8 +905,8 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
         }
 
         $callParenthesis = $tokens->findBlockStart(
-            Tokens::BLOCK_TYPE_PARENTHESIS_BRACE,
-            $receiver,
+            type: Tokens::BLOCK_TYPE_PARENTHESIS_BRACE,
+            searchIndex: $receiver,
         );
 
         $nameIndex = $tokens->getPrevMeaningfulToken($callParenthesis);
@@ -906,6 +955,63 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
         return $ownerClass === null
             ? null
             : $this->resolveMethodReturnClass($ownerClass, $callable[ 'name' ]);
+    }
+
+    private function resolveSourceParameterClass(Tokens $tokens, int $position, string $variable, ?int $classIndex): ?string
+    {
+        for ($scopeIndex = count($this->callableScopes) - 1; $scopeIndex >= 0; $scopeIndex--) {
+
+            $scope = $this->callableScopes[ $scopeIndex ];
+
+            if ($position < $scope[ 'start' ] || $position > $scope[ 'end' ]) {
+                continue;
+            }
+
+            foreach ($this->argumentRanges(
+                tokens: $tokens,
+                openParenthesis: $scope[ 'openParenthesis' ],
+                closeParenthesis: $scope[ 'closeParenthesis' ],
+            ) as $range) {
+
+                for ($index = $range[ 'start' ]; $index <= $range[ 'end' ]; $index++) {
+
+                    if ($tokens[ $index ]->isGivenKind(T_VARIABLE) === false
+                        || $tokens[ $index ]->getContent() !== $variable) {
+                        continue;
+                    }
+
+                    $typeIndex = $tokens->getPrevMeaningfulToken($index);
+
+                    if ($typeIndex !== null
+                        && in_array($tokens[ $typeIndex ]->getContent(), [ '&', '...' ], true)) {
+                        $typeIndex = $tokens->getPrevMeaningfulToken($typeIndex);
+                    }
+
+                    if ($typeIndex === null || $this->isNameToken($tokens[ $typeIndex ]) === false) {
+                        return null;
+                    }
+
+                    $beforeType = $tokens->getPrevMeaningfulToken($typeIndex);
+
+                    if ($beforeType !== null
+                        && $beforeType >= $range[ 'start' ]
+                        && in_array($tokens[ $beforeType ]->getContent(), [ '|', '&' ], true)) {
+                        return null;
+                    }
+
+                    return $this->resolveClassReference(
+                        identifier: $tokens[ $typeIndex ]->getContent(),
+                        position: $index,
+                        classIndex: $classIndex,
+                    );
+
+                }
+
+            }
+
+        }
+
+        return null;
     }
 
     private function resolvePropertyReceiverClass(Tokens $tokens, int $property, ?int $classIndex): ?string

--- a/tests/Fixtures/MultilineNamedArgumentsFixer/After/ParameterReceiverCalls.php
+++ b/tests/Fixtures/MultilineNamedArgumentsFixer/After/ParameterReceiverCalls.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\MultilineNamedArgumentsFixer;
+
+use DigitalCreative\ECS\Tests\Support\ReflectionMemoryManager;
+
+final class OAuthUser
+{
+}
+
+final class MemoryWriteToolData
+{
+    public string $query;
+
+    public ?int $limit;
+}
+
+final class ParameterReceiverCalls
+{
+    private function forget(OAuthUser $user, MemoryWriteToolData $data, ReflectionMemoryManager $manager, object $memories): array
+    {
+        return $manager->forgetTopic(
+            owner: $user,
+            query: (string) $data->query,
+            limit: $data->limit ?? 10,
+        );
+    }
+}

--- a/tests/Fixtures/MultilineNamedArgumentsFixer/Before/ParameterReceiverCalls.php
+++ b/tests/Fixtures/MultilineNamedArgumentsFixer/Before/ParameterReceiverCalls.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\MultilineNamedArgumentsFixer;
+
+use DigitalCreative\ECS\Tests\Support\ReflectionMemoryManager;
+
+final class OAuthUser
+{
+}
+
+final class MemoryWriteToolData
+{
+    public string $query;
+
+    public ?int $limit;
+}
+
+final class ParameterReceiverCalls
+{
+    private function forget(
+        OAuthUser $user,
+        MemoryWriteToolData $data,
+        ReflectionMemoryManager $manager,
+        object $memories,
+    ): array
+    {
+        return $manager->forgetTopic(
+            $user,
+            (string) $data->query,
+            $data->limit ?? 10,
+        );
+    }
+}

--- a/tests/MultilineNamedArgumentsFixerTest.php
+++ b/tests/MultilineNamedArgumentsFixerTest.php
@@ -48,6 +48,16 @@ final class MultilineNamedArgumentsFixerTest extends EcsTestCase
         );
     }
 
+    public function test_typed_parameter_receivers_use_resolved_parameter_names(): void
+    {
+        $fixtureDirectory = __DIR__ . '/Fixtures/MultilineNamedArgumentsFixer';
+
+        $this->assertFixtureIsFixedTo(
+            inputFixture: $fixtureDirectory . '/Before/ParameterReceiverCalls.php',
+            expectedFixture: $fixtureDirectory . '/After/ParameterReceiverCalls.php',
+        );
+    }
+
     public function test_namespace_alias_and_source_inheritance_are_resolved(): void
     {
         $fixtureDirectory = __DIR__ . '/Fixtures/MultilineNamedArgumentsFixer';

--- a/tests/Support/ReflectionMemoryManager.php
+++ b/tests/Support/ReflectionMemoryManager.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Support;
+
+final class ReflectionMemoryManager
+{
+    public function forgetTopic(object $owner, string $query, int $limit): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
## Summary
- resolve method calls on typed function and method parameters, not only `$this` and typed properties
- preserve nested callable scope precedence while resolving imported, source-declared, and reflected receiver classes
- convert the reported `MemoryManager $manager` call to `owner:`, `query:`, and `limit:` arguments
- add native before/after fixtures backed by a reflection-loaded manager class

## Verification
- `php vendor/bin/phpunit --do-not-cache-result tests` — 50 tests, 109 assertions passed
- `php vendor/bin/phpunit --do-not-cache-result --filter test_typed_parameter_receivers_use_resolved_parameter_names tests/MultilineNamedArgumentsFixerTest.php` — 1 test, 2 assertions passed
- ECS check for the changed fixer, test, support class, and expected fixture — passed
- direct reproduction changed `$manager->forgetTopic($user, (string) $data->query, ...)` to `owner:`, `query:`, and `limit:`

The repository has no `main` branch; this PR targets its current default branch, `development`.
