### PR TITLE
Pad adjacent docblocks and containerize tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/composer.lock
+/vendor/

--- a/composer
+++ b/composer
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+set -eu
+
+exec docker compose run --rm --user "$(id -u):$(id -g)" php composer "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  php:
+    image: composer:2
+    working_dir: /app
+    environment:
+      COMPOSER_HOME: /tmp/composer
+    volumes:
+      - .:/app

--- a/justfile
+++ b/justfile
@@ -1,0 +1,3 @@
+test:
+    ./composer install --no-interaction --prefer-dist
+    ./composer test

--- a/php
+++ b/php
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+set -eu
+
+exec docker compose run --rm --user "$(id -u):$(id -g)" php php "$@"

--- a/src/Custom.php
+++ b/src/Custom.php
@@ -13,6 +13,7 @@ use DigitalCreative\ECS\Fixers\LaravelEmptyToBlankFixer;
 use DigitalCreative\ECS\Fixers\MultilineNamedArgumentsFixer;
 use DigitalCreative\ECS\Fixers\PaddedArrayFixer;
 use DigitalCreative\ECS\Fixers\PaddedBlockFixer;
+use DigitalCreative\ECS\Fixers\PaddedDocblockFixer;
 use DigitalCreative\ECS\Fixers\PaddedMultilineStatementFixer;
 use DigitalCreative\ECS\Fixers\StatementGroupingFixer;
 use DigitalCreative\ECS\Fixers\TraitUseSpacingFixer;
@@ -23,6 +24,7 @@ return register_fixers(fixers: [
     AutoImportClassesFixer::class => true,
     PaddedArrayFixer::class => true,
     PaddedBlockFixer::class => true,
+    PaddedDocblockFixer::class => true,
     PaddedMultilineStatementFixer::class => true,
     StatementGroupingFixer::class => true,
     TraitUseSpacingFixer::class => true,

--- a/src/Fixers/PaddedDocblockFixer.php
+++ b/src/Fixers/PaddedDocblockFixer.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Fixers;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\IndentationTrait;
+use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+
+final class PaddedDocblockFixer extends AbstractFixer implements WhitespacesAwareFixerInterface
+{
+    use IndentationTrait;
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            summary: 'Docblocks following completed statements or blocks must have a blank line before them.',
+            codeSamples: [],
+        );
+    }
+
+    public function getPriority(): int
+    {
+        return -105;
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_DOC_COMMENT);
+    }
+
+    protected function applyFix(SplFileInfo $file, Tokens $tokens): void
+    {
+        for ($index = $tokens->count() - 1; $index >= 0; $index--) {
+
+            if ($tokens[ $index ]->isGivenKind(T_DOC_COMMENT) === false) {
+                continue;
+            }
+
+            $previous = $tokens->getPrevMeaningfulToken($index);
+
+            if ($previous === null || $tokens[ $previous ]->equalsAny([ ';', '}' ]) === false) {
+                continue;
+            }
+
+            if ($tokens->getPrevNonWhitespace($index) !== $previous) {
+                continue;
+            }
+
+            $this->ensureBlankLineBefore($tokens, $index);
+
+        }
+    }
+
+    private function ensureBlankLineBefore(Tokens $tokens, int $docblock): void
+    {
+        $lineEnding = $this->whitespacesConfig->getLineEnding();
+        $whitespace = $docblock - 1;
+
+        if ($tokens[ $whitespace ]->isWhitespace() === false) {
+
+            $tokens->insertAt(
+                index: $docblock,
+                items: new Token([
+                    T_WHITESPACE,
+                    sprintf(
+                        '%1$s%1$s%2$s',
+                        $lineEnding,
+                        $this->getLineIndentation($tokens, $docblock),
+                    ),
+                ]),
+            );
+
+            return;
+
+        }
+
+        $content = $tokens[ $whitespace ]->getContent();
+
+        if (substr_count($content, "\n") >= 2) {
+            return;
+        }
+
+        if (str_contains($content, "\n")) {
+
+            $tokens[ $whitespace ] = new Token([
+                T_WHITESPACE,
+                sprintf('%s%s', $lineEnding, $content),
+            ]);
+
+            return;
+
+        }
+
+        $tokens[ $whitespace ] = new Token([
+            T_WHITESPACE,
+            sprintf(
+                '%1$s%1$s%2$s',
+                $lineEnding,
+                $this->getLineIndentation($tokens, $docblock),
+            ),
+        ]);
+    }
+}

--- a/tests/Fixtures/PaddedDocblockFixer/After/AdjacentDocblocks.php
+++ b/tests/Fixtures/PaddedDocblockFixer/After/AdjacentDocblocks.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\PaddedDocblockFixer;
+
+final class AdjacentDocblocks
+{
+    /**
+     * @var list<string>
+     */
+    private array $keys = [];
+
+    public function reconcile(object $existingByKey, object $definition): void
+    {
+        /**
+         * @var Experiment|null $existing
+         */
+        $existing = $existingByKey->get($definition->key);
+
+        /**
+         * @var Experiment|null $existingForDecisionContext
+         */
+        $existingForDecisionContext = $existingByKey->first(
+            static fn (Experiment $candidate): bool => $candidate->decision_point === $definition->decisionPoint
+                && $candidate->context_key === $definition->contextKey,
+        );
+
+        /**
+         * @var Experiment|null $existing
+         */
+        $existing = $existingForDecisionContext;
+
+        /**
+         * @var Experiment|null $existing
+         */
+        $existing = $existingByKey->get($definition->key);
+    }
+}

--- a/tests/Fixtures/PaddedDocblockFixer/Before/AdjacentDocblocks.php
+++ b/tests/Fixtures/PaddedDocblockFixer/Before/AdjacentDocblocks.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\PaddedDocblockFixer;
+
+final class AdjacentDocblocks
+{
+    /**
+     * @var list<string>
+     */
+    private array $keys = [];
+
+    public function reconcile(object $existingByKey, object $definition): void
+    {
+        /**
+         * @var Experiment|null $existing
+         */
+        $existing = $existingByKey->get($definition->key);
+        /**
+         * @var Experiment|null $existingForDecisionContext
+         */
+        $existingForDecisionContext = $existingByKey->first(
+            static fn (Experiment $candidate): bool => $candidate->decision_point === $definition->decisionPoint
+                && $candidate->context_key === $definition->contextKey,
+        );
+
+        /**
+         * @var Experiment|null $existing
+         */
+        $existing = $existingForDecisionContext;
+        /**
+         * @var Experiment|null $existing
+         */
+        $existing = $existingByKey->get($definition->key);
+    }
+}

--- a/tests/PaddedDocblockFixerTest.php
+++ b/tests/PaddedDocblockFixerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests;
+
+use DigitalCreative\ECS\Tests\Support\EcsTestCase;
+
+final class PaddedDocblockFixerTest extends EcsTestCase
+{
+    public function test_docblocks_following_statements_have_a_blank_line_before_them(): void
+    {
+        $fixtureDirectory = __DIR__ . '/Fixtures/PaddedDocblockFixer';
+
+        $this->assertFixtureIsFixedTo(
+            inputFixture: $fixtureDirectory . '/Before/AdjacentDocblocks.php',
+            expectedFixture: $fixtureDirectory . '/After/AdjacentDocblocks.php',
+        );
+    }
+
+    public function test_padded_docblocks_are_idempotent(): void
+    {
+        $this->assertFixturePasses(
+            __DIR__ . '/Fixtures/PaddedDocblockFixer/After/AdjacentDocblocks.php',
+        );
+    }
+}

--- a/tests/Support/EcsTestCase.php
+++ b/tests/Support/EcsTestCase.php
@@ -27,19 +27,19 @@ abstract class EcsTestCase extends AbstractCheckerTestCase
     final protected function assertFixtureIsFixedTo(string $inputFixture, string $expectedFixture): void
     {
         $this->assertCodeIsFixedTo(
-            $this->readFixture($inputFixture),
-            $this->readFixture($expectedFixture),
-            basename($inputFixture),
+            input: $this->readFixture($inputFixture),
+            expected: $this->readFixture($expectedFixture),
+            temporaryFilename: basename($inputFixture),
         );
     }
 
     final protected function assertLaravelFixtureIsFixedTo(string $inputFixture, string $expectedFixture): void
     {
         $this->assertCodeIsFixedTo(
-            $this->readFixture($inputFixture),
-            $this->readFixture($expectedFixture),
-            basename($inputFixture),
-            true,
+            input: $this->readFixture($inputFixture),
+            expected: $this->readFixture($expectedFixture),
+            temporaryFilename: basename($inputFixture),
+            laravelProject: true,
         );
     }
 
@@ -50,13 +50,11 @@ abstract class EcsTestCase extends AbstractCheckerTestCase
         $this->assertCodeIsFixedTo($source, $source, basename($fixture));
     }
 
-    final protected function assertCodeIsFixedTo(
-        string $input,
-        string $expected,
-        string $temporaryFilename = 'fixture.php',
-        bool $laravelProject = false,
-    ): void
+    final protected function assertCodeIsFixedTo(string $input, string $expected, string $temporaryFilename = 'fixture.php', bool $laravelProject = false): void
     {
+        $input = $this->normalizeLineEndings($input);
+        $expected = $this->normalizeLineEndings($expected);
+
         self::assertNotEmpty($this->fixerFileProcessor->getCheckers(), 'The ECS configuration registered no fixers.');
 
         $temporaryDirectory = sprintf(
@@ -80,7 +78,12 @@ abstract class EcsTestCase extends AbstractCheckerTestCase
         }
 
         try {
-            self::assertSame($expected, $this->fixerFileProcessor->processFileToString($temporaryFile));
+
+            self::assertSame(
+                expected: $expected,
+                actual: $this->normalizeLineEndings($this->fixerFileProcessor->processFileToString($temporaryFile)),
+            );
+
         } finally {
 
             unlink($temporaryFile);
@@ -118,5 +121,10 @@ abstract class EcsTestCase extends AbstractCheckerTestCase
         }
 
         return $contents;
+    }
+
+    private function normalizeLineEndings(string $code): string
+    {
+        return str_replace([ "\r\n", "\r" ], "\n", $code);
     }
 }


### PR DESCRIPTION
## Summary
- add `PaddedDocblockFixer` so a docblock directly following a completed statement or block receives a blank line before it while remaining attached to the declaration or assignment it documents
- add regression fixtures for the reported adjacent `@var` assignments, repeated receiver assignments, and idempotent formatted output
- add a Docker Compose PHP runtime plus executable `./php` and `./composer` wrappers modeled after sibling projects
- add `just test`, which installs dependencies in the container and runs the Composer test script
- enforce LF checkouts and normalize fixture assertion line endings so containerized tests are independent of the host Git line-ending configuration
- ignore generated `vendor/` and `composer.lock` artifacts

## Verification
- `just test` — 56 tests, 121 assertions passed
- focused `PaddedDocblockFixerTest` — 2 tests, 4 assertions passed
- changed-file ECS check — passed
- `docker compose config --quiet` — passed
- `./php --version` — PHP 8.5.8 in the container
- `./composer --version` — Composer 2.10.2 in the container
- `sh -n php composer` — passed
- direct smoke run added exactly one blank line between the reported first assignment and the following docblock
