### PR TITLE
Resolve named arguments through class-string functions

### DIFF
--- a/src/Fixers/MultilineNamedArgumentsFixer.php
+++ b/src/Fixers/MultilineNamedArgumentsFixer.php
@@ -8,6 +8,7 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use ReflectionClass;
@@ -1032,7 +1033,15 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
 
         if ($beforeName === null
             || $tokens[ $beforeName ]->isGivenKind([ T_OBJECT_OPERATOR, T_NULLSAFE_OBJECT_OPERATOR ]) === false) {
-            return $this->resolveFunctionReturnClass($callable[ 'name' ], $position);
+
+            return $this->resolveFunctionReturnClass($callable[ 'name' ], $position)
+                ?? $this->resolveClassStringFunctionClass(
+                    tokens: $tokens,
+                    openParenthesis: $callParenthesis,
+                    closeParenthesis: $receiver,
+                    classIndex: $classIndex,
+                );
+
         }
 
         $innerReceiver = $tokens->getPrevMeaningfulToken($beforeName);
@@ -1046,6 +1055,74 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
         return $ownerClass === null
             ? null
             : $this->resolveMethodReturnClass($ownerClass, $callable[ 'name' ]);
+    }
+
+    private function resolveClassStringFunctionClass(Tokens $tokens, int $openParenthesis, int $closeParenthesis, ?int $classIndex): ?string
+    {
+        $resolvedClass = null;
+
+        foreach ($this->argumentRanges($tokens, $openParenthesis, $closeParenthesis) as $argument) {
+
+            $argumentClass = $this->resolveClassConstantArgument($tokens, $argument, $classIndex);
+
+            if ($argumentClass === null) {
+                continue;
+            }
+
+            if ($resolvedClass !== null) {
+                return null;
+            }
+
+            $resolvedClass = $argumentClass;
+
+        }
+
+        return $resolvedClass;
+    }
+
+    /**
+     * @param array{start: int, end: int} $argument
+     */
+    private function resolveClassConstantArgument(Tokens $tokens, array $argument, ?int $classIndex): ?string
+    {
+        $className = $tokens->getNextMeaningfulToken($argument[ 'start' ] - 1);
+
+        if ($className === null || $className > $argument[ 'end' ]) {
+            return null;
+        }
+
+        $separator = $tokens->getNextMeaningfulToken($className);
+
+        if ($separator !== null && $tokens[ $separator ]->getContent() === ':') {
+            $className = $tokens->getNextMeaningfulToken($separator);
+        }
+
+        if ($className === null
+            || $className > $argument[ 'end' ]
+            || $this->isNameToken($tokens[ $className ]) === false) {
+            return null;
+        }
+
+        $staticOperator = $tokens->getNextMeaningfulToken($className);
+        $classConstant = $staticOperator === null ? null : $tokens->getNextMeaningfulToken($staticOperator);
+
+        if ($staticOperator === null
+            || $classConstant === null
+            || $classConstant > $argument[ 'end' ]
+            || $tokens[ $staticOperator ]->isGivenKind(T_DOUBLE_COLON) === false
+            || $tokens[ $classConstant ]->isGivenKind(CT::T_CLASS_CONSTANT) === false) {
+            return null;
+        }
+
+        $afterClassConstant = $tokens->getNextMeaningfulToken($classConstant);
+
+        if ($afterClassConstant !== null && $afterClassConstant <= $argument[ 'end' ]) {
+            return null;
+        }
+
+        $classReference = $this->readQualifiedNameEndingAt($tokens, $className);
+
+        return $this->resolveClassReference($classReference[ 'name' ], $className, $classIndex);
     }
 
     /**

--- a/tests/Fixtures/MultilineNamedArgumentsFixer/After/ClassStringFunctionCalls.php
+++ b/tests/Fixtures/MultilineNamedArgumentsFixer/After/ClassStringFunctionCalls.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\MultilineNamedArgumentsFixer;
+
+use DigitalCreative\ECS\Tests\Support\ReflectionRecordManager as RecordManager;
+
+function project_factory(string $implementation)
+{
+    return unknown_factory($implementation);
+}
+
+abstract class ClassStringFunctionCalls
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    protected function handleRecordUpdate(object $record, array $data): object
+    {
+        /**
+         * @var Experiment $record
+         */
+        return app(RecordManager::class)->update(
+            record: $record,
+            data: LandingGroupData::fromFilament($data),
+        );
+    }
+
+    public function resolveFrameworkFunction(object $record, object $data): object
+    {
+        return \framework_resolve(service: RecordManager::class)->update(
+            record: $record,
+            data: $data,
+        );
+    }
+
+    public function resolveWithArbitraryArgumentPosition(object $record, object $data): object
+    {
+        return custom_factory(options: [], implementation: RecordManager::class)->update(
+            record: $record,
+            data: $data,
+        );
+    }
+
+    public function resolveProjectFactory(object $record, object $data): object
+    {
+        return project_factory(RecordManager::class)->update(
+            record: $record,
+            data: $data,
+        );
+    }
+}

--- a/tests/Fixtures/MultilineNamedArgumentsFixer/Before/ClassStringFunctionCalls.php
+++ b/tests/Fixtures/MultilineNamedArgumentsFixer/Before/ClassStringFunctionCalls.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\MultilineNamedArgumentsFixer;
+
+use DigitalCreative\ECS\Tests\Support\ReflectionRecordManager as RecordManager;
+
+function project_factory(string $implementation)
+{
+    return unknown_factory($implementation);
+}
+
+abstract class ClassStringFunctionCalls
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    protected function handleRecordUpdate(object $record, array $data): object
+    {
+        /**
+         * @var Experiment $record
+         */
+        return app(RecordManager::class)->update(
+            $record,
+            LandingGroupData::fromFilament($data),
+        );
+    }
+
+    public function resolveFrameworkFunction(object $record, object $data): object
+    {
+        return \framework_resolve(service: RecordManager::class)->update(
+            $record,
+            $data,
+        );
+    }
+
+    public function resolveWithArbitraryArgumentPosition(object $record, object $data): object
+    {
+        return custom_factory(options: [], implementation: RecordManager::class)->update(
+            $record,
+            $data,
+        );
+    }
+
+    public function resolveProjectFactory(object $record, object $data): object
+    {
+        return project_factory(RecordManager::class)->update(
+            $record,
+            $data,
+        );
+    }
+}

--- a/tests/Fixtures/MultilineNamedArgumentsFixer/Valid/AmbiguousClassStringFunctionCalls.php
+++ b/tests/Fixtures/MultilineNamedArgumentsFixer/Valid/AmbiguousClassStringFunctionCalls.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\MultilineNamedArgumentsFixer;
+
+final class AmbiguousClassStringFunctionCalls
+{
+    public function exercise(object $record, object $data, string $manager): void
+    {
+        select_factory(FirstManager::class, SecondManager::class)->update(
+            $record,
+            $data,
+        );
+
+        dynamic_factory($manager)->update(
+            $record,
+            $data,
+        );
+    }
+}

--- a/tests/MultilineNamedArgumentsFixerTest.php
+++ b/tests/MultilineNamedArgumentsFixerTest.php
@@ -88,6 +88,23 @@ final class MultilineNamedArgumentsFixerTest extends EcsTestCase
         );
     }
 
+    public function test_class_string_function_receivers_use_resolved_parameter_names(): void
+    {
+        $fixtureDirectory = __DIR__ . '/Fixtures/MultilineNamedArgumentsFixer';
+
+        $this->assertFixtureIsFixedTo(
+            inputFixture: $fixtureDirectory . '/Before/ClassStringFunctionCalls.php',
+            expectedFixture: $fixtureDirectory . '/After/ClassStringFunctionCalls.php',
+        );
+    }
+
+    public function test_class_string_function_output_is_idempotent(): void
+    {
+        $this->assertFixturePasses(
+            fixture: __DIR__ . '/Fixtures/MultilineNamedArgumentsFixer/After/ClassStringFunctionCalls.php',
+        );
+    }
+
     public function test_already_named_multiline_calls_are_idempotent(): void
     {
         $this->assertFixturePasses(
@@ -120,6 +137,13 @@ final class MultilineNamedArgumentsFixerTest extends EcsTestCase
     {
         $this->assertFixturePasses(
             fixture: __DIR__ . '/Fixtures/MultilineNamedArgumentsFixer/Valid/AmbiguousLocalReceivers.php',
+        );
+    }
+
+    public function test_ambiguous_and_dynamic_class_string_functions_are_left_unchanged(): void
+    {
+        $this->assertFixturePasses(
+            fixture: __DIR__ . '/Fixtures/MultilineNamedArgumentsFixer/Valid/AmbiguousClassStringFunctionCalls.php',
         );
     }
 }

--- a/tests/Support/ReflectionRecordManager.php
+++ b/tests/Support/ReflectionRecordManager.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Support;
+
+final class ReflectionRecordManager
+{
+    public function update(object $record, object $data): object
+    {
+        return $record;
+    }
+}


### PR DESCRIPTION
## Summary
- resolve chained function-call receivers generically, with no Laravel or framework-specific function names
- keep source and reflected return types as the first source of truth
- when a function has no resolvable return class, infer the receiver from one unambiguous exact `ClassName::class` argument at any positional or named argument position
- resolve the chained method on that class and inject names only when its parameter list is known
- skip dynamic class strings, zero or multiple class-string candidates, and complex expressions rather than guessing
- cover `app(...)`, arbitrary framework functions, project-defined untyped factories, arbitrary named argument positions, imported aliases, idempotency, and ambiguity safeguards

A function with neither a declared/reflected return class nor one unambiguous class-string argument remains unchanged because its runtime receiver type cannot be established safely without executing application code.

## Verification
- focused generic function receiver coverage — 3 tests, 6 assertions passed
- `just test` — 59 tests, 127 assertions passed
- changed-file ECS check — passed
- framework-neutral smoke run transformed `framework_service(RecordManager::class)->update(...)` to `record:` and `data:`