### PR TITLE
Resolve named arguments across dynamic scopes

### DIFF
--- a/src/Fixers/MultilineNamedArgumentsFixer.php
+++ b/src/Fixers/MultilineNamedArgumentsFixer.php
@@ -1290,16 +1290,19 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
     private function resolveLocalVariableClass(Tokens $tokens, int $variableIndex, ?int $classIndex): array
     {
         $scopeIndex = $this->findContainingCallableScope($variableIndex);
+        $contextIndex = $this->findNamespaceContext($variableIndex);
+        $scopeStart = $contextIndex === null
+            ? -1
+            : $this->namespaceContexts[ $contextIndex ][ 'start' ] - 1;
 
-        if ($scopeIndex === null) {
-            return [ 'found' => false, 'class' => null ];
+        if ($scopeIndex !== null) {
+            $scopeStart = $this->callableScopes[ $scopeIndex ][ 'start' ];
         }
 
-        $scope = $this->callableScopes[ $scopeIndex ];
         $useBlock = $this->findContainingCurlyBlock($variableIndex);
         $variable = $tokens[ $variableIndex ]->getContent();
 
-        for ($index = $variableIndex - 1; $index > $scope[ 'start' ]; $index--) {
+        for ($index = $variableIndex - 1; $index > $scopeStart; $index--) {
 
             if ($tokens[ $index ]->isGivenKind(T_VARIABLE) === false
                 || $tokens[ $index ]->getContent() !== $variable
@@ -1340,7 +1343,48 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
 
         }
 
-        return [ 'found' => false, 'class' => null ];
+        if ($scopeIndex === null) {
+            return [ 'found' => false, 'class' => null ];
+        }
+
+        $capture = $this->findClosureCapture($tokens, $scopeIndex, $variable);
+
+        return $capture === null
+            ? [ 'found' => false, 'class' => null ]
+            : $this->resolveLocalVariableClass($tokens, $capture, $classIndex);
+    }
+
+    private function findClosureCapture(Tokens $tokens, int $scopeIndex, string $variable): ?int
+    {
+        $scope = $this->callableScopes[ $scopeIndex ];
+        $useIndex = $tokens->getNextMeaningfulToken($scope[ 'closeParenthesis' ]);
+
+        if ($useIndex === null
+            || $tokens[ $useIndex ]->isGivenKind([ T_USE, CT::T_USE_LAMBDA ]) === false) {
+            return null;
+        }
+
+        $openParenthesis = $tokens->getNextMeaningfulToken($useIndex);
+
+        if ($openParenthesis === null || $tokens[ $openParenthesis ]->equals('(') === false) {
+            return null;
+        }
+
+        $closeParenthesis = $tokens->findBlockEnd(
+            type: Tokens::BLOCK_TYPE_PARENTHESIS_BRACE,
+            searchIndex: $openParenthesis,
+        );
+
+        for ($index = $openParenthesis + 1; $index < $closeParenthesis; $index++) {
+
+            if ($tokens[ $index ]->isGivenKind(T_VARIABLE)
+                && $tokens[ $index ]->getContent() === $variable) {
+                return $index;
+            }
+
+        }
+
+        return null;
     }
 
     private function findAssignmentExpressionEnd(Tokens $tokens, int $assignmentOperator, int $boundary): ?int
@@ -1840,7 +1884,18 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
 
         $reflectionMethod = $this->reflectMethod($className, $method);
 
-        return $reflectionMethod === null ? null : $this->resolveReflectedMethodReturnClass($reflectionMethod);
+        if ($reflectionMethod !== null) {
+            return $this->resolveReflectedMethodReturnClass($reflectionMethod);
+        }
+
+        $magicMethod = $this->reflectMagicMethod($className, $method);
+
+        return $magicMethod === null || $magicMethod[ 'returnType' ] === null
+            ? null
+            : $this->resolveReflectedTypeName(
+                type: $magicMethod[ 'returnType' ],
+                declaringClass: $magicMethod[ 'declaringClass' ],
+            );
     }
 
     /**
@@ -1856,9 +1911,11 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
 
         $reflectionMethod = $this->reflectMethod($className, $method);
 
-        return $reflectionMethod === null
-            ? null
-            : $this->reflectionParameters($reflectionMethod->getParameters());
+        if ($reflectionMethod !== null) {
+            return $this->reflectionParameters($reflectionMethod->getParameters());
+        }
+
+        return $this->reflectMagicMethod($className, $method)[ 'parameters' ] ?? null;
     }
 
     private function reflectMethod(string $className, string $method): ?ReflectionMethod
@@ -1876,6 +1933,268 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
             return null;
 
         }
+    }
+
+    /**
+     * @return array{
+     *     returnType: string|null,
+     *     parameters: list<array{name: string, variadic: bool}>,
+     *     declaringClass: ReflectionClass
+     * }|null
+     */
+    private function reflectMagicMethod(string $className, string $method): ?array
+    {
+        try {
+
+            if (class_exists($className) === false
+                && interface_exists($className) === false
+                && trait_exists($className) === false) {
+                return null;
+            }
+
+            return $this->findReflectionMagicMethod(new ReflectionClass($className), $method);
+
+        } catch (Throwable) {
+
+            return null;
+
+        }
+    }
+
+    /**
+     * @return array{
+     *     returnType: string|null,
+     *     parameters: list<array{name: string, variadic: bool}>,
+     *     declaringClass: ReflectionClass
+     * }|null
+     */
+    private function findReflectionMagicMethod(ReflectionClass $class, string $method, array $visited = []): ?array
+    {
+        $className = strtolower($class->getName());
+
+        if (isset($visited[ $className ])) {
+            return null;
+        }
+
+        $visited[ $className ] = true;
+        $magicMethod = $this->parseReflectionMagicMethod($class, $method);
+
+        if ($magicMethod !== null) {
+            return $magicMethod;
+        }
+
+        foreach ($class->getTraits() as $trait) {
+
+            $magicMethod = $this->findReflectionMagicMethod($trait, $method, $visited);
+
+            if ($magicMethod !== null) {
+                return $magicMethod;
+            }
+
+        }
+
+        foreach ($this->reflectionMixinClassNames($class) as $mixinClassName) {
+
+            if (class_exists($mixinClassName) === false && interface_exists($mixinClassName) === false) {
+                continue;
+            }
+
+            $magicMethod = $this->findReflectionMagicMethod(
+                class: new ReflectionClass($mixinClassName),
+                method: $method,
+                visited: $visited,
+            );
+
+            if ($magicMethod !== null) {
+                return $magicMethod;
+            }
+
+        }
+
+        $parent = $class->getParentClass();
+
+        if ($parent !== false) {
+
+            $magicMethod = $this->findReflectionMagicMethod($parent, $method, $visited);
+
+            if ($magicMethod !== null) {
+                return $magicMethod;
+            }
+
+        }
+
+        foreach ($class->getInterfaces() as $interface) {
+
+            $magicMethod = $this->findReflectionMagicMethod($interface, $method, $visited);
+
+            if ($magicMethod !== null) {
+                return $magicMethod;
+            }
+
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{
+     *     returnType: string|null,
+     *     parameters: list<array{name: string, variadic: bool}>,
+     *     declaringClass: ReflectionClass
+     * }|null
+     */
+    private function parseReflectionMagicMethod(ReflectionClass $class, string $method): ?array
+    {
+        $docComment = $class->getDocComment();
+
+        if ($docComment === false) {
+            return null;
+        }
+
+        $lines = preg_split('/\R/', $docComment);
+
+        if ($lines === false) {
+            return null;
+        }
+
+        foreach ($lines as $line) {
+
+            if (preg_match(
+                pattern: '/@method\s+(?:static\s+)?(?:(?<returnType>[^\s(]+)\s+)?(?<method>[A-Za-z_][A-Za-z0-9_]*)\s*\((?<parameters>.*)\)/',
+                subject: $line,
+                matches: $matches,
+            ) !== 1 || strcasecmp($matches[ 'method' ], $method) !== 0) {
+                continue;
+            }
+
+            $parameters = $this->parseMagicMethodParameters($matches[ 'parameters' ]);
+
+            if ($parameters === null) {
+                return null;
+            }
+
+            return [
+                'returnType' => $matches[ 'returnType' ] === '' ? null : $matches[ 'returnType' ],
+                'parameters' => $parameters,
+                'declaringClass' => $class,
+            ];
+
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<array{name: string, variadic: bool}>|null
+     */
+    private function parseMagicMethodParameters(string $parameters): ?array
+    {
+        if (trim($parameters) === '') {
+            return [];
+        }
+
+        $resolvedParameters = [];
+
+        foreach ($this->splitTopLevelParameters($parameters) as $parameter) {
+
+            if (preg_match_all(
+                pattern: '/&?\s*(?<variadic>\.\.\.)?\s*\$(?<name>[A-Za-z_][A-Za-z0-9_]*)/',
+                subject: $parameter,
+                matches: $matches,
+                flags: PREG_SET_ORDER,
+            ) < 1) {
+                return null;
+            }
+
+            $match = $matches[ array_key_last($matches) ];
+            $resolvedParameters[] = [
+                'name' => $match[ 'name' ],
+                'variadic' => $match[ 'variadic' ] !== '',
+            ];
+
+        }
+
+        return $resolvedParameters;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function splitTopLevelParameters(string $parameters): array
+    {
+        $parts = [];
+        $start = 0;
+        $depth = 0;
+        $quote = null;
+        $escaped = false;
+        $length = strlen($parameters);
+
+        for ($index = 0; $index < $length; $index++) {
+
+            $character = $parameters[ $index ];
+
+            if ($quote !== null) {
+
+                if ($escaped) {
+
+                    $escaped = false;
+
+                    continue;
+
+                }
+
+                if ($character === '\\') {
+
+                    $escaped = true;
+
+                    continue;
+
+                }
+
+                if ($character === $quote) {
+                    $quote = null;
+                }
+
+                continue;
+
+            }
+
+            if ($character === "'" || $character === '"') {
+
+                $quote = $character;
+
+                continue;
+
+            }
+
+            if (str_contains('([{<', $character)) {
+
+                $depth++;
+
+                continue;
+
+            }
+
+            if (str_contains(')]}>', $character)) {
+
+                $depth = max(0, $depth - 1);
+
+                continue;
+
+            }
+
+            if ($character !== ',' || $depth !== 0) {
+                continue;
+            }
+
+            $parts[] = trim(substr($parameters, $start, $index - $start));
+            $start = $index + 1;
+
+        }
+
+        $parts[] = trim(substr($parameters, $start));
+
+        return $parts;
     }
 
     private function findReflectionMethod(ReflectionClass $class, string $method, array $visited = []): ?ReflectionMethod

--- a/tests/Fixtures/MultilineNamedArgumentsFixer/After/CapturedClosureCalls.php
+++ b/tests/Fixtures/MultilineNamedArgumentsFixer/After/CapturedClosureCalls.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\MultilineNamedArgumentsFixer;
+
+use DigitalCreative\ECS\Tests\Support\ReflectionDatabaseConnection;
+use DigitalCreative\ECS\Tests\Support\ReflectionMagicConnectionFacade;
+use DigitalCreative\ECS\Tests\Support\ReflectionPestTestCase;
+use stdClass;
+
+uses(ReflectionPestTestCase::class);
+
+$connection = ReflectionMagicConnectionFacade::connection('events');
+$directConnection = new ReflectionDatabaseConnection();
+$reportingRole = 'reporting';
+
+test('captured receivers retain their inferred type', function () use ($connection, $directConnection, $reportingRole): void {
+
+    $directConnection->selectOne(
+        query: 'directly constructed captured receiver',
+        bindings: [ $reportingRole ],
+    );
+
+    $connection->transaction(function () use ($connection, $reportingRole): object {
+
+        $attributes = $connection->selectOne(
+            query: 'select * from pg_roles where rolname = ?',
+            bindings: [ $reportingRole ],
+        );
+
+        return $attributes ?? new stdClass();
+
+    });
+
+    $lookup = static fn (): ?object => $connection->selectOne(
+        query: 'select * from pg_roles where rolname in (?, ?)',
+        bindings: [ new stdClass(), $reportingRole ],
+    );
+
+    unset($lookup);
+
+});
+
+return new class ()
+{
+    public function run(): void
+    {
+        $connection = ReflectionMagicConnectionFacade::connection('events');
+        $reportingRole = 'reporting';
+
+        retry(
+            times: 5,
+            callback: function () use ($connection, $reportingRole): void {
+
+                $connection->transaction(function () use ($connection, $reportingRole): object {
+
+                    $attributes = $connection->selectOne(
+                        query: 'select rolsuper, rolcreatedb from pg_roles where rolname = ?',
+                        bindings: [ $reportingRole ],
+                    );
+
+                    return $attributes ?? new stdClass();
+
+                });
+
+            },
+        );
+    }
+};

--- a/tests/Fixtures/MultilineNamedArgumentsFixer/After/ReceiverContextMatrix.php
+++ b/tests/Fixtures/MultilineNamedArgumentsFixer/After/ReceiverContextMatrix.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\MultilineNamedArgumentsFixer;
+
+use DigitalCreative\ECS\Tests\Support\ReflectionDatabaseConnection;
+use DigitalCreative\ECS\Tests\Support\ReflectionMagicConnectionFacade;
+use stdClass;
+
+function reflectedConnection(): ReflectionDatabaseConnection
+{
+    return ReflectionMagicConnectionFacade::connection('events');
+}
+
+function queryFromFunction(ReflectionDatabaseConnection $connection, object $context): void
+{
+    $connection->write(
+        query: 'function query',
+        bindings: [ 'context' => $context ],
+        context: $context,
+    );
+}
+
+trait QueriesFromTrait
+{
+    private function queryFromTrait(ReflectionDatabaseConnection $connection, object $context): void
+    {
+        $connection->write(
+            query: 'trait query',
+            bindings: [ 'nested' => [ $context ] ],
+            context: $context,
+        );
+    }
+}
+
+final class QueryService
+{
+    use QueriesFromTrait;
+
+    public function run(ReflectionDatabaseConnection $connection, object $context): void
+    {
+        $this->queryFromTrait($connection, $context);
+    }
+}
+
+$context = new stdClass();
+$connection = reflectedConnection();
+$magicConnection = ReflectionMagicConnectionFacade::connection('events');
+
+$magicConnection->selectOne(
+    query: 'magic return query',
+    bindings: [ $context ],
+);
+
+$connection->write(
+    query: 'top-level query',
+    bindings: [ $context ],
+    context: $context,
+);
+
+ReflectionMagicConnectionFacade::selectOne(
+    query: 'direct facade query',
+    bindings: [ $context ],
+);
+
+ReflectionMagicConnectionFacade::dispatch(
+    callback: static fn (object $payload, array $metadata): object => $payload,
+    options: [ 'objects' => [ $context ] ],
+);
+
+ReflectionMagicConnectionFacade::write(
+    query: 'trait-provided magic query',
+    bindings: [ 'objects' => [ $context ] ],
+    context: $context,
+);
+
+queryFromFunction($connection, $context);

--- a/tests/Fixtures/MultilineNamedArgumentsFixer/Before/CapturedClosureCalls.php
+++ b/tests/Fixtures/MultilineNamedArgumentsFixer/Before/CapturedClosureCalls.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\MultilineNamedArgumentsFixer;
+
+use DigitalCreative\ECS\Tests\Support\ReflectionDatabaseConnection;
+use DigitalCreative\ECS\Tests\Support\ReflectionMagicConnectionFacade;
+use DigitalCreative\ECS\Tests\Support\ReflectionPestTestCase;
+use stdClass;
+
+uses(ReflectionPestTestCase::class);
+
+$connection = ReflectionMagicConnectionFacade::connection('events');
+$directConnection = new ReflectionDatabaseConnection();
+$reportingRole = 'reporting';
+
+test('captured receivers retain their inferred type', function () use ($connection, $directConnection, $reportingRole): void {
+
+    $directConnection->selectOne(
+        'directly constructed captured receiver',
+        [ $reportingRole ],
+    );
+
+    $connection->transaction(function () use ($connection, $reportingRole): object {
+
+        $attributes = $connection->selectOne(
+            'select * from pg_roles where rolname = ?',
+            [ $reportingRole ],
+        );
+
+        return $attributes ?? new stdClass();
+
+    });
+
+    $lookup = static fn (): ?object => $connection->selectOne(
+        'select * from pg_roles where rolname in (?, ?)',
+        [ new stdClass(), $reportingRole ],
+    );
+
+    unset($lookup);
+
+});
+
+return new class ()
+{
+    public function run(): void
+    {
+        $connection = ReflectionMagicConnectionFacade::connection('events');
+        $reportingRole = 'reporting';
+
+        retry(
+            times: 5,
+            callback: function () use ($connection, $reportingRole): void {
+
+                $connection->transaction(function () use ($connection, $reportingRole): object {
+
+                    $attributes = $connection->selectOne(
+                        'select rolsuper, rolcreatedb from pg_roles where rolname = ?',
+                        [ $reportingRole ],
+                    );
+
+                    return $attributes ?? new stdClass();
+
+                });
+
+            },
+        );
+    }
+};

--- a/tests/Fixtures/MultilineNamedArgumentsFixer/Before/ReceiverContextMatrix.php
+++ b/tests/Fixtures/MultilineNamedArgumentsFixer/Before/ReceiverContextMatrix.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\MultilineNamedArgumentsFixer;
+
+use DigitalCreative\ECS\Tests\Support\ReflectionDatabaseConnection;
+use DigitalCreative\ECS\Tests\Support\ReflectionMagicConnectionFacade;
+use stdClass;
+
+function reflectedConnection(): ReflectionDatabaseConnection
+{
+    return ReflectionMagicConnectionFacade::connection('events');
+}
+
+function queryFromFunction(ReflectionDatabaseConnection $connection, object $context): void
+{
+    $connection->write(
+        'function query',
+        [ 'context' => $context ],
+        $context,
+    );
+}
+
+trait QueriesFromTrait
+{
+    private function queryFromTrait(ReflectionDatabaseConnection $connection, object $context): void
+    {
+        $connection->write(
+            'trait query',
+            [ 'nested' => [ $context ] ],
+            $context,
+        );
+    }
+}
+
+final class QueryService
+{
+    use QueriesFromTrait;
+
+    public function run(ReflectionDatabaseConnection $connection, object $context): void
+    {
+        $this->queryFromTrait($connection, $context);
+    }
+}
+
+$context = new stdClass();
+$connection = reflectedConnection();
+$magicConnection = ReflectionMagicConnectionFacade::connection('events');
+
+$magicConnection->selectOne(
+    'magic return query',
+    [ $context ],
+);
+
+$connection->write(
+    'top-level query',
+    [ $context ],
+    $context,
+);
+
+ReflectionMagicConnectionFacade::selectOne(
+    'direct facade query',
+    [ $context ],
+);
+
+ReflectionMagicConnectionFacade::dispatch(
+    static fn (object $payload, array $metadata): object => $payload,
+    [ 'objects' => [ $context ] ],
+);
+
+ReflectionMagicConnectionFacade::write(
+    'trait-provided magic query',
+    [ 'objects' => [ $context ] ],
+    $context,
+);
+
+queryFromFunction($connection, $context);

--- a/tests/Fixtures/MultilineNamedArgumentsFixer/Valid/AmbiguousScopeAndMagicCalls.php
+++ b/tests/Fixtures/MultilineNamedArgumentsFixer/Valid/AmbiguousScopeAndMagicCalls.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\MultilineNamedArgumentsFixer;
+
+use DigitalCreative\ECS\Tests\Support\ReflectionDatabaseConnection;
+use DigitalCreative\ECS\Tests\Support\ReflectionMagicConnectionFacade;
+use stdClass;
+
+if (random_int(0, 1) === 1) {
+    $conditionalConnection = new ReflectionDatabaseConnection();
+}
+
+$conditionalConnection->write(
+    'conditional assignment is ambiguous',
+    [ new stdClass() ],
+    new stdClass(),
+);
+
+$ambiguousConnection = ReflectionMagicConnectionFacade::ambiguous('events');
+
+$ambiguousConnection->write(
+    'union magic return is ambiguous',
+    [ new stdClass() ],
+    new stdClass(),
+);
+
+$dynamicConnection = unknown_connection();
+$callback = function () use ($dynamicConnection): void {
+
+    $dynamicConnection->write(
+        'unknown captured assignment is ambiguous',
+        [ new stdClass() ],
+        new stdClass(),
+    );
+
+};

--- a/tests/MultilineNamedArgumentsFixerTest.php
+++ b/tests/MultilineNamedArgumentsFixerTest.php
@@ -115,6 +115,40 @@ final class MultilineNamedArgumentsFixerTest extends EcsTestCase
         );
     }
 
+    public function test_magic_methods_functions_traits_top_level_calls_and_complex_arguments_are_resolved(): void
+    {
+        $fixtureDirectory = __DIR__ . '/Fixtures/MultilineNamedArgumentsFixer';
+
+        $this->assertFixtureIsFixedTo(
+            inputFixture: $fixtureDirectory . '/Before/ReceiverContextMatrix.php',
+            expectedFixture: $fixtureDirectory . '/After/ReceiverContextMatrix.php',
+        );
+    }
+
+    public function test_captured_receivers_are_resolved_through_nested_test_and_arrow_function_scopes(): void
+    {
+        $fixtureDirectory = __DIR__ . '/Fixtures/MultilineNamedArgumentsFixer';
+
+        $this->assertFixtureIsFixedTo(
+            inputFixture: $fixtureDirectory . '/Before/CapturedClosureCalls.php',
+            expectedFixture: $fixtureDirectory . '/After/CapturedClosureCalls.php',
+        );
+    }
+
+    public function test_comprehensive_receiver_context_output_is_idempotent(): void
+    {
+        $this->assertFixturePasses(
+            fixture: __DIR__ . '/Fixtures/MultilineNamedArgumentsFixer/After/ReceiverContextMatrix.php',
+        );
+    }
+
+    public function test_captured_receiver_output_is_idempotent(): void
+    {
+        $this->assertFixturePasses(
+            fixture: __DIR__ . '/Fixtures/MultilineNamedArgumentsFixer/After/CapturedClosureCalls.php',
+        );
+    }
+
     public function test_class_string_function_output_is_idempotent(): void
     {
         $this->assertFixturePasses(
@@ -154,6 +188,13 @@ final class MultilineNamedArgumentsFixerTest extends EcsTestCase
     {
         $this->assertFixturePasses(
             fixture: __DIR__ . '/Fixtures/MultilineNamedArgumentsFixer/Valid/AmbiguousLocalReceivers.php',
+        );
+    }
+
+    public function test_ambiguous_top_level_magic_and_captured_receivers_are_left_unchanged(): void
+    {
+        $this->assertFixturePasses(
+            fixture: __DIR__ . '/Fixtures/MultilineNamedArgumentsFixer/Valid/AmbiguousScopeAndMagicCalls.php',
         );
     }
 

--- a/tests/Support/ReflectionDatabaseConnection.php
+++ b/tests/Support/ReflectionDatabaseConnection.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Support;
+
+use Closure;
+
+final class ReflectionDatabaseConnection
+{
+    public function selectOne(string $query, array $bindings = [], bool $useReadPdo = true): ?object
+    {
+        return null;
+    }
+
+    public function write(string $query, array $bindings, object $context): object
+    {
+        return $context;
+    }
+
+    public function transaction(Closure $callback): object
+    {
+        return $callback();
+    }
+}

--- a/tests/Support/ReflectionMagicConnectionFacade.php
+++ b/tests/Support/ReflectionMagicConnectionFacade.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Support;
+
+/**
+ * @method static ReflectionDatabaseConnection connection(string $name)
+ * @method static object|null selectOne(string $query, array $bindings = [], bool $useReadPdo = true)
+ * @method static object dispatch(callable(object $payload, array $metadata): object $callback, array $options = [])
+ * @method static ReflectionDatabaseConnection|object ambiguous(string $name)
+ */
+final class ReflectionMagicConnectionFacade
+{
+    use ReflectionMagicQueryMethods;
+}

--- a/tests/Support/ReflectionMagicQueryMethods.php
+++ b/tests/Support/ReflectionMagicQueryMethods.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Support;
+
+/**
+ * @method static object write(string $query, array $bindings = [ 'fallback' => [ 1, 2 ] ], object $context = new \stdClass())
+ */
+trait ReflectionMagicQueryMethods
+{
+}


### PR DESCRIPTION
## Summary
- follow local receiver types through top-level assignments and arbitrarily nested closure `use (...)` captures
- resolve reflected magic `@method` declarations, including return types needed for facade factories and parameter names needed for direct magic calls
- search magic metadata across classes, traits, mixins, parents, and interfaces while preferring real reflected methods
- parse complex PHPDoc parameters containing nested callable signatures, arrays, objects, defaults, and variadics without splitting nested commas
- keep conditional assignments, unknown captures, and union magic return types unchanged rather than guessing

## Root cause
The reported receiver crosses two previously unsupported boundaries:

1. `DB::connection(...)` is a Laravel facade magic method. Reflection reports `hasMethod('connection') === false`; its `Illuminate\Database\Connection` return type exists only in the facade's `@method` PHPDoc.
2. `$connection` is assigned in `up()` and then captured through two nested closures. Local inference stopped at the innermost callable and did not follow `CT::T_USE_LAMBDA` captures back to the assignment.

## Coverage matrix
- native and magic receiver factories
- direct magic methods and trait-provided magic metadata
- named functions and methods inside traits
- top-level assignments
- Pest test closures, nested closures, anonymous classes, and arrow functions
- string, nested-array, object, and callable arguments
- idempotency and ambiguity safeguards

## Verification
- `./php vendor/bin/phpunit --do-not-cache-result tests/MultilineNamedArgumentsFixerTest.php` — 23 tests, 46 assertions passed
- `./composer test` — 66 tests, 141 assertions passed
- changed implementation, expected fixtures, safeguards, and support types passed ECS
- application smoke check transformed the reported `selectOne()` call to `query:` and `bindings:`