### PR TITLE
Fix class-string resolution when functions have complex PHPDoc return types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,10 @@
     "autoload-dev": {
         "psr-4": {
             "DigitalCreative\\ECS\\Tests\\": "tests/"
-        }
+        },
+        "files": [
+            "tests/Support/complex_return_app.php"
+        ]
     },
     "scripts": {
         "test": "phpunit --do-not-cache-result tests"

--- a/src/Fixers/MultilineNamedArgumentsFixer.php
+++ b/src/Fixers/MultilineNamedArgumentsFixer.php
@@ -2358,6 +2358,10 @@ final class MultilineNamedArgumentsFixer extends AbstractFixer
             return null;
         }
 
+        if (preg_match('/[^a-zA-Z0-9_\\\\]/', $type)) {
+            return null;
+        }
+
         return str_starts_with($type, '\\')
             ? ltrim($type, '\\')
             : $this->qualifyName($declaringClass->getNamespaceName(), $type);

--- a/tests/Fixtures/MultilineNamedArgumentsFixer/After/ClassStringFunctionCallsInArrowFunctions.php
+++ b/tests/Fixtures/MultilineNamedArgumentsFixer/After/ClassStringFunctionCallsInArrowFunctions.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\MultilineNamedArgumentsFixer;
+
+use Closure;
+use DigitalCreative\ECS\Tests\Support\ReflectionRecordManager as RecordManager;
+use stdClass;
+
+abstract class ClassStringFunctionCallsInArrowFunctions
+{
+    protected function saveCampaignConfiguration(Closure $callback): mixed
+    {
+        return $callback();
+    }
+
+    protected function handleRecordUpdate(RecordManager $record, array $data): RecordManager
+    {
+        /**
+         * @var RecordManager $record
+         */
+        return $this->saveCampaignConfiguration(
+            static fn (): RecordManager => app(RecordManager::class)->update(
+                record: $record,
+                data: LandingGroupData::fromFilament($data),
+            ),
+        );
+    }
+
+    protected function handleRecordUpdateArrowFn(RecordManager $record, array $data): RecordManager
+    {
+        return $this->saveCampaignConfiguration(
+            fn (): RecordManager => app(RecordManager::class)->update(
+                record: $record,
+                data: LandingGroupData::fromFilament($data),
+            ),
+        );
+    }
+
+    public function chainedCallWithNestedArrowFn(): mixed
+    {
+        return retry(
+            times: 5,
+            callback: function (): mixed {
+
+                return app(RecordManager::class)->update(
+                    record: new RecordManager(),
+                    data: new stdClass(),
+                );
+
+            },
+        );
+    }
+}

--- a/tests/Fixtures/MultilineNamedArgumentsFixer/After/ComplexReturnTypeClassStringCalls.php
+++ b/tests/Fixtures/MultilineNamedArgumentsFixer/After/ComplexReturnTypeClassStringCalls.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\MultilineNamedArgumentsFixer;
+
+use Closure;
+
+use function DigitalCreative\ECS\Tests\Support\complex_return_app;
+
+use DigitalCreative\ECS\Tests\Support\ReflectionRecordManager as RecordManager;
+
+abstract class ComplexReturnTypeClassStringCalls
+{
+    protected function handleRecordUpdate(RecordManager $record, array $data): RecordManager
+    {
+        return complex_return_app(RecordManager::class)->update(
+            record: $record,
+            data: LandingGroupData::fromFilament($data),
+        );
+    }
+
+    protected function handleNestedUpdate(RecordManager $record, array $data): RecordManager
+    {
+        return $this->wrap(
+            static fn (): RecordManager => complex_return_app(RecordManager::class)->update(
+                record: $record,
+                data: LandingGroupData::fromFilament($data),
+            ),
+        );
+    }
+
+    protected function wrap(Closure $callback): mixed
+    {
+        return $callback();
+    }
+}

--- a/tests/Fixtures/MultilineNamedArgumentsFixer/Before/ClassStringFunctionCallsInArrowFunctions.php
+++ b/tests/Fixtures/MultilineNamedArgumentsFixer/Before/ClassStringFunctionCallsInArrowFunctions.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\MultilineNamedArgumentsFixer;
+
+use DigitalCreative\ECS\Tests\Support\ReflectionRecordManager as RecordManager;
+
+abstract class ClassStringFunctionCallsInArrowFunctions
+{
+    protected function saveCampaignConfiguration(\Closure $callback): mixed
+    {
+        return $callback();
+    }
+
+    protected function handleRecordUpdate(RecordManager $record, array $data): RecordManager
+    {
+        /**
+         * @var RecordManager $record
+         */
+        return $this->saveCampaignConfiguration(
+            static fn (): RecordManager => app(RecordManager::class)->update(
+                $record,
+                LandingGroupData::fromFilament($data),
+            ),
+        );
+    }
+
+    protected function handleRecordUpdateArrowFn(RecordManager $record, array $data): RecordManager
+    {
+        return $this->saveCampaignConfiguration(
+            fn (): RecordManager => app(RecordManager::class)->update(
+                $record,
+                LandingGroupData::fromFilament($data),
+            ),
+        );
+    }
+
+    public function chainedCallWithNestedArrowFn(): mixed
+    {
+        return retry(
+            times: 5,
+            callback: function (): mixed {
+                return app(RecordManager::class)->update(
+                    new RecordManager(),
+                    new \stdClass(),
+                );
+            },
+        );
+    }
+}

--- a/tests/Fixtures/MultilineNamedArgumentsFixer/Before/ComplexReturnTypeClassStringCalls.php
+++ b/tests/Fixtures/MultilineNamedArgumentsFixer/Before/ComplexReturnTypeClassStringCalls.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Fixtures\MultilineNamedArgumentsFixer;
+
+use DigitalCreative\ECS\Tests\Support\ReflectionRecordManager as RecordManager;
+
+use function DigitalCreative\ECS\Tests\Support\complex_return_app;
+
+abstract class ComplexReturnTypeClassStringCalls
+{
+    protected function handleRecordUpdate(RecordManager $record, array $data): RecordManager
+    {
+        return complex_return_app(RecordManager::class)->update(
+            $record,
+            LandingGroupData::fromFilament($data),
+        );
+    }
+
+    protected function handleNestedUpdate(RecordManager $record, array $data): RecordManager
+    {
+        return $this->wrap(
+            static fn (): RecordManager => complex_return_app(RecordManager::class)->update(
+                $record,
+                LandingGroupData::fromFilament($data),
+            ),
+        );
+    }
+
+    protected function wrap(\Closure $callback): mixed
+    {
+        return $callback();
+    }
+}

--- a/tests/MultilineNamedArgumentsFixerTest.php
+++ b/tests/MultilineNamedArgumentsFixerTest.php
@@ -204,4 +204,24 @@ final class MultilineNamedArgumentsFixerTest extends EcsTestCase
             fixture: __DIR__ . '/Fixtures/MultilineNamedArgumentsFixer/Valid/AmbiguousClassStringFunctionCalls.php',
         );
     }
+
+    public function test_class_string_in_static_and_regular_arrow_functions_resolves_names(): void
+    {
+        $fixtureDirectory = __DIR__ . '/Fixtures/MultilineNamedArgumentsFixer';
+
+        $this->assertFixtureIsFixedTo(
+            inputFixture: $fixtureDirectory . '/Before/ClassStringFunctionCallsInArrowFunctions.php',
+            expectedFixture: $fixtureDirectory . '/After/ClassStringFunctionCallsInArrowFunctions.php',
+        );
+    }
+
+    public function test_class_string_function_with_complex_return_type_resolves_names(): void
+    {
+        $fixtureDirectory = __DIR__ . '/Fixtures/MultilineNamedArgumentsFixer';
+
+        $this->assertFixtureIsFixedTo(
+            inputFixture: $fixtureDirectory . '/Before/ComplexReturnTypeClassStringCalls.php',
+            expectedFixture: $fixtureDirectory . '/After/ComplexReturnTypeClassStringCalls.php',
+        );
+    }
 }

--- a/tests/Support/complex_return_app.php
+++ b/tests/Support/complex_return_app.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace DigitalCreative\ECS\Tests\Support;
+
+use stdClass;
+
+/**
+ * Simulates Laravel's app() helper with a complex conditional return type.
+ *
+ * @template TClass of object
+ *
+ * @param class-string<TClass>|string|null $abstract
+ *
+ * @return ($abstract is class-string<TClass> ? TClass : ($abstract is null ? object : mixed))
+ */
+function complex_return_app(string|null $abstract = null): mixed
+{
+    return $abstract !== null ? new $abstract() : new stdClass();
+}


### PR DESCRIPTION
## Problem

When a function like Laravel's `app()` has a complex conditional return type in its PHPDoc (`@return ($abstract is class-string<TClass> ? TClass : ...)`), the regex `/@return\s+([^\s]+)/` captures `($abstract` as the return type. This is not null, so `resolveFunctionReturnClass` returns it as a "class name". The `??` fallback to `resolveClassStringFunctionClass` never fires, and the fixer fails to resolve the chained method call.

In the test environment, `app()` doesn't exist as a real function, so the class-string fallback always worked. This is why the existing tests passed while the real application code was not transformed.

## Fix

Add a validation in `resolveReflectedTypeName` that rejects types containing characters invalid for PHP class names (anything other than alphanumeric, underscores, and namespace separators). When the bogus `($abstract` type is rejected, `resolveFunctionReturnClass` returns null, and the `??` fallback to `resolveClassStringFunctionClass` correctly resolves `app(TrafficSourceManager::class)` → `TrafficSourceManager` → `update(source, data)`.

## Test

- `complex_return_app()` function in `tests/Support/` simulates Laravel's `app()` with the exact same complex `@return` type
- Fixture exercises the pattern both as a direct call and inside `static fn` arrow functions (the reported Filament pattern)
- Arrow-function fixture also covers `app(RecordManager::class)->update()` inside `static fn`, regular `fn`, and `function()` closures

## Verification

- 68 tests, 145 assertions pass
- ECS formatting passes for all implementation, expected fixtures, and support files
- The `app(RecordManager::class)->update(...)` pattern inside all closure types is correctly transformed to `record:` and `data:` named arguments